### PR TITLE
chore: add beta-feedback issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug Report
+description: Report an autocomplete misfire, install crash, or performance regression.
+title: "[Bug]: "
+labels:
+  - beta-feedback
+body:
+  - type: dropdown
+    id: shell
+    attributes:
+      label: Shell
+      description: Which shell are you using?
+      options:
+        - zsh
+        - bash
+        - fish
+    validations:
+      required: true
+
+  - type: input
+    id: shell-version
+    attributes:
+      label: Shell version
+      description: Output of `zsh --version` (or equivalent for your shell).
+      placeholder: "zsh 5.9 (x86_64-apple-darwin23.0)"
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS and version
+      placeholder: "macOS 14.4.1 / Ubuntu 22.04"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - "Homebrew via Neftedollar/homebrew-shac"
+        - "curl | sh"
+        - "Source build"
+    validations:
+      required: true
+
+  - type: input
+    id: shac-version
+    attributes:
+      label: shac version
+      description: Output of `shac --version`.
+      placeholder: "shac 0.1.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction steps
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Open a new terminal session
+        2. Type `git che` and press Tab
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal / multiplexer (optional)
+      description: e.g. iTerm2, Alacritty, tmux, Warp, Ghostty
+      placeholder: "iTerm2 3.5.2 + tmux 3.4"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Q&A / General Questions
+    # TODO: replace with the GitHub Discussions Q&A category URL once AGE-20 enables Discussions
+    url: https://github.com/Neftedollar/sh-autocomplete/discussions
+    about: For general questions, use GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/shell_integration_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/shell_integration_feedback.yml
@@ -1,0 +1,68 @@
+name: Shell Integration Feedback
+description: Share feedback on completion hooks, latency, and conflicts with other tools.
+title: "[Integration]: "
+labels:
+  - beta-feedback
+body:
+  - type: dropdown
+    id: shell
+    attributes:
+      label: Shell
+      options:
+        - zsh
+        - bash
+        - fish
+    validations:
+      required: true
+
+  - type: dropdown
+    id: shell-framework
+    attributes:
+      label: Shell framework
+      options:
+        - oh-my-zsh
+        - prezto
+        - starship
+        - none
+        - other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-completion-tools
+    attributes:
+      label: Other completion tools running
+      description: List any other completion or suggestion tools active in your shell.
+      placeholder: "fzf, zsh-autosuggestions, fish abbr, ..."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: perceived-latency
+    attributes:
+      label: Perceived latency on common commands
+      description: How does shac's completion speed feel on everyday commands?
+      options:
+        - Instant (< 50 ms)
+        - Acceptable (50–200 ms)
+        - Noticeable (200–500 ms)
+        - Slow (> 500 ms)
+    validations:
+      required: true
+
+  - type: textarea
+    id: key-conflicts
+    attributes:
+      label: Key conflicts
+      description: Is shac taking over key bindings you want to use for something else?
+      placeholder: "shac intercepts Ctrl+Space which I use for fzf"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other integration issues, edge cases, or suggestions.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ux_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/ux_feedback.yml
@@ -1,0 +1,68 @@
+name: UX Feedback
+description: Share thoughts on discoverability, suggestion quality, and ergonomics.
+title: "[UX]: "
+labels:
+  - beta-feedback
+body:
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install shac?
+      options:
+        - "Homebrew via Neftedollar/homebrew-shac"
+        - "curl | sh"
+        - "Source build"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: usage-duration
+    attributes:
+      label: How long have you been using shac?
+      options:
+        - Less than a day
+        - 1–7 days
+        - 1–4 weeks
+        - More than a month
+    validations:
+      required: true
+
+  - type: textarea
+    id: top-commands
+    attributes:
+      label: Top 3 commands you typed most
+      description: The commands you use most frequently where shac's suggestions showed up.
+      placeholder: |
+        1. git
+        2. docker
+        3. kubectl
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-vs-actual
+    attributes:
+      label: I expected X but got Y
+      description: Describe any moments where shac's suggestions surprised or disappointed you.
+      placeholder: "I expected `git checkout` completions to show branch names, but got file paths instead."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: would-recommend
+    attributes:
+      label: Would you recommend shac to a colleague?
+      options:
+        - "Yes"
+        - "No"
+        - "Maybe"
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: General ergonomics notes, discoverability issues, or ideas.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds three structured YAML issue templates and a `config.yml` for the `Neftedollar/sh-autocomplete` beta. All templates are labelled `beta-feedback` so the synthesis routine can discover them automatically.

**Templates added:**
- `bug_report.yml` — autocomplete misfires, install crashes, perf regressions. Captures shell, shell version, OS, install method, shac version, repro steps, expected vs actual, optional terminal/multiplexer.
- `shell_integration_feedback.yml` — completion hooks, latency, key-binding conflicts. Captures shell, framework, other completion tools, latency perception.
- `ux_feedback.yml` — discoverability, suggestion quality, ergonomics. Captures install method, usage duration, top-3 commands, expected-vs-actual free text, would-recommend.
- `config.yml` — disables blank issues; has a TODO placeholder for the GitHub Discussions Q&A URL (pending [AGE-20]).

## Test plan
- [ ] Open a new issue in this repo and verify the three templates appear in the template picker
- [ ] Confirm blank issue creation is disabled
- [ ] Verify each template pre-fills the `beta-feedback` label

🤖 Generated with [Paperclip](https://paperclip.ing)