### PR TITLE
feat(7.11/7.5b/7.5c): background indexer, reindex flags, invalidate-caches

### DIFF
--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -275,14 +275,18 @@ fn main() -> Result<()> {
         Commands::Debug(args) => debug_action(&paths, args.action),
         Commands::Reindex(args) => {
             ensure_daemon(&paths)?;
-            // --full overrides --skip-existing; no flags = default (skip-existing=false, full=false)
+            // --full overrides --skip-existing; no flags = default (skip_existing=true, full=false)
             let full = args.full;
+            // When --full is set, skip_existing is forced false. Otherwise default to true
+            // (incremental), which --skip-existing also explicitly requests.
+            let skip_existing = !full;
             let value = send_request(
                 &paths,
                 "reindex",
                 serde_json::json!({
                     "path_env": std::env::var("PATH").ok(),
                     "full": full,
+                    "skip_existing": skip_existing,
                 }),
             )?;
             println!("{}", serde_json::to_string_pretty(&value)?);

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -31,7 +31,8 @@ enum Commands {
     Index(IndexArgs),
     Doctor(DoctorArgs),
     Debug(DebugArgs),
-    Reindex,
+    Reindex(ReindexArgs),
+    InvalidateCaches,
     Explain(CompletionArgs),
     Complete(CompletionArgs),
     RecordCommand(RecordArgs),
@@ -45,6 +46,16 @@ enum Commands {
     TrainModel(TrainModelArgs),
     Import(ImportArgs),
     ScanProjects(ScanProjectsArgs),
+}
+
+#[derive(Debug, Args)]
+struct ReindexArgs {
+    /// Re-import everything from scratch, replacing existing indexed entries.
+    #[arg(long, conflicts_with = "skip_existing")]
+    full: bool,
+    /// Only add new entries; skip commands that are already indexed (default behaviour).
+    #[arg(long)]
+    skip_existing: bool,
 }
 
 #[derive(Debug, Args)]
@@ -262,14 +273,25 @@ fn main() -> Result<()> {
         Commands::Index(args) => index_action(&paths, args.action),
         Commands::Doctor(args) => doctor(&paths, args),
         Commands::Debug(args) => debug_action(&paths, args.action),
-        Commands::Reindex => {
+        Commands::Reindex(args) => {
             ensure_daemon(&paths)?;
+            // --full overrides --skip-existing; no flags = default (skip-existing=false, full=false)
+            let full = args.full;
             let value = send_request(
                 &paths,
                 "reindex",
-                serde_json::json!({ "path_env": std::env::var("PATH").ok() }),
+                serde_json::json!({
+                    "path_env": std::env::var("PATH").ok(),
+                    "full": full,
+                }),
             )?;
             println!("{}", serde_json::to_string_pretty(&value)?);
+            Ok(())
+        }
+        Commands::InvalidateCaches => {
+            ensure_daemon(&paths)?;
+            send_request(&paths, "invalidate-caches", serde_json::json!({}))?;
+            println!("caches invalidated");
             Ok(())
         }
         Commands::Explain(args) => explain(&paths, args),

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -294,7 +294,10 @@ fn main() -> Result<()> {
         }
         Commands::InvalidateCaches => {
             ensure_daemon(&paths)?;
-            send_request(&paths, "invalidate-caches", serde_json::json!({}))?;
+            let resp = send_request(&paths, "invalidate-caches", serde_json::json!({}))?;
+            if let Some(err) = resp.get("error").and_then(|e| e.as_str()) {
+                bail!("daemon error: {err}");
+            }
             println!("caches invalidated");
             Ok(())
         }

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -3,11 +3,15 @@ use std::io::ErrorKind;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use shac::config::AppPaths;
+use shac::db::AppDb;
 use shac::engine::{self, Engine};
+use shac::indexer;
 use shac::protocol::RecordCommandRequest;
 
 #[derive(Debug, Parser)]
@@ -33,6 +37,28 @@ fn main() -> Result<()> {
         eprintln!("shac: personalized model activated");
     }
     let engine = Engine::new(&paths)?;
+
+    // Background indexer: opens its own DB connection (WAL-safe) and
+    // incrementally indexes --help output for all PATH executables.
+    // Waits 2s after daemon start to avoid competing with first completions,
+    // then loops every 6 hours.  Uses skip_existing=true so it never
+    // overwrites manually-indexed docs or reindexes commands already in DB.
+    {
+        let db_path = paths.db_file.clone();
+        let path_env = std::env::var("PATH").ok();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(2));
+            loop {
+                match AppDb::open(&db_path)
+                    .and_then(|db| indexer::reindex_path_commands(&db, path_env.as_deref(), true, true))
+                {
+                    Ok(n) => eprintln!("shac: background indexed {} commands", n),
+                    Err(e) => eprintln!("shac: background index error: {e}"),
+                }
+                thread::sleep(Duration::from_secs(6 * 3600));
+            }
+        });
+    }
 
     for stream in listener.incoming() {
         match stream {
@@ -100,8 +126,17 @@ fn handle_client(engine: &Engine, mut stream: UnixStream) -> Result<()> {
                 .get("payload")
                 .and_then(|payload| payload.get("path_env"))
                 .and_then(|value| value.as_str());
-            let indexed = engine.reindex(path_env)?;
+            let full = request
+                .get("payload")
+                .and_then(|payload| payload.get("full"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let indexed = engine.reindex(path_env, full)?;
             serde_json::to_vec(&serde_json::json!({ "indexed": indexed }))?
+        }
+        "invalidate-caches" => {
+            engine.invalidate_caches();
+            br#"{"ok":true}"#.to_vec()
         }
         "stats" => serde_json::to_vec(&engine.stats()?)?,
         _ => serde_json::to_vec(

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
             let mut fail_count: usize = 0;
             loop {
                 match AppDb::open(&db_path)
-                    .and_then(|db| indexer::reindex_path_commands(&db, path_env.as_deref(), false, true))
+                    .and_then(|db| indexer::reindex_path_commands(&db, path_env.as_deref(), true, true))
                 {
                     Ok(n) => {
                         eprintln!("shac: background indexed {} commands", n);

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -14,6 +14,8 @@ use shac::engine::{self, Engine};
 use shac::indexer;
 use shac::protocol::RecordCommandRequest;
 
+const BG_REINDEX_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+
 #[derive(Debug, Parser)]
 struct Args {
     #[arg(long)]
@@ -41,21 +43,49 @@ fn main() -> Result<()> {
     // Background indexer: opens its own DB connection (WAL-safe) and
     // incrementally indexes --help output for all PATH executables.
     // Waits 2s after daemon start to avoid competing with first completions,
-    // then loops every 6 hours.  Uses skip_existing=true so it never
-    // overwrites manually-indexed docs or reindexes commands already in DB.
+    // then loops every BG_REINDEX_INTERVAL.  Uses skip_existing=true so it
+    // never overwrites manually-indexed docs or reindexes commands already in DB.
+    // On transient errors, retries with exponential backoff (60s → 300s → cap).
+    //
+    // SHAC_BG_REINDEX_INTERVAL_SECS and SHAC_BG_SETTLE_SECS override the intervals
+    // at runtime — intended for integration tests only.
     {
         let db_path = paths.db_file.clone();
         let path_env = std::env::var("PATH").ok();
+        let reindex_interval = std::env::var("SHAC_BG_REINDEX_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(BG_REINDEX_INTERVAL);
+        let settle_secs = std::env::var("SHAC_BG_SETTLE_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(2);
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(2));
+            thread::sleep(Duration::from_secs(settle_secs));
+            // Backoff schedule for consecutive failures: 60s, 300s, then cap at reindex_interval.
+            let backoff = [
+                Duration::from_secs(60).min(reindex_interval),
+                Duration::from_secs(300).min(reindex_interval),
+                reindex_interval,
+            ];
+            let mut fail_count: usize = 0;
             loop {
                 match AppDb::open(&db_path)
-                    .and_then(|db| indexer::reindex_path_commands(&db, path_env.as_deref(), true, true))
+                    .and_then(|db| indexer::reindex_path_commands(&db, path_env.as_deref(), false, true))
                 {
-                    Ok(n) => eprintln!("shac: background indexed {} commands", n),
-                    Err(e) => eprintln!("shac: background index error: {e}"),
+                    Ok(n) => {
+                        eprintln!("shac: background indexed {} commands", n);
+                        fail_count = 0;
+                        thread::sleep(reindex_interval);
+                    }
+                    Err(e) => {
+                        eprintln!("shac: background index error: {e}");
+                        let idx = fail_count.min(backoff.len() - 1);
+                        thread::sleep(backoff[idx]);
+                        fail_count = fail_count.saturating_add(1);
+                    }
                 }
-                thread::sleep(Duration::from_secs(6 * 3600));
             }
         });
     }
@@ -131,7 +161,13 @@ fn handle_client(engine: &Engine, mut stream: UnixStream) -> Result<()> {
                 .and_then(|payload| payload.get("full"))
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            let indexed = engine.reindex(path_env, full)?;
+            // Default skip_existing=true (safer/incremental); --full overrides it to false.
+            let skip_existing = request
+                .get("payload")
+                .and_then(|payload| payload.get("skip_existing"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let indexed = engine.reindex(path_env, full, skip_existing)?;
             serde_json::to_vec(&serde_json::json!({ "indexed": indexed }))?
         }
         "invalidate-caches" => {

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -49,7 +49,14 @@ fn main() -> Result<()> {
     //
     // SHAC_BG_REINDEX_INTERVAL_SECS and SHAC_BG_SETTLE_SECS override the intervals
     // at runtime — intended for integration tests only.
+    // Set SHAC_BG_DISABLED=1 to skip spawning the thread entirely (used by tests).
+    if std::env::var("SHAC_BG_DISABLED")
+        .ok()
+        .filter(|v| !v.is_empty() && v != "0")
+        .is_some()
     {
+        eprintln!("shacd: bg indexer disabled via SHAC_BG_DISABLED");
+    } else {
         let db_path = paths.db_file.clone();
         let path_env = std::env::var("PATH").ok();
         let reindex_interval = std::env::var("SHAC_BG_REINDEX_INTERVAL_SECS")

--- a/src/db.rs
+++ b/src/db.rs
@@ -842,6 +842,15 @@ impl AppDb {
         Ok(())
     }
 
+    /// Drop all memoized in-process caches: the SQLite `dir_cache` rows that
+    /// store directory-listing snapshots keyed by mtime.  After this call the
+    /// next completion request re-reads every directory from disk.  Safe to
+    /// call at any time; no daemon restart required.
+    pub fn invalidate_caches(&self) {
+        // Ignore errors — if the table does not exist yet (empty DB) that is fine.
+        let _ = self.conn.execute("DELETE FROM dir_cache", []);
+    }
+
     /// Bump frecency for a path (rank += 1.0, clamped to 100.0). On insert, rank=1.0.
     pub fn upsert_path_index(
         &self,
@@ -2109,6 +2118,24 @@ mod tests {
         let row = top.iter().find(|p| p.path == "/tmp/foo").unwrap();
         assert_eq!(row.visit_count, 3);
         assert!(row.rank >= 3.0);
+    }
+
+    #[test]
+    fn invalidate_caches_clears_dir_cache() {
+        let db = test_db();
+        db.upsert_dir_cache("/tmp/testdir", 12345, "file1\nfile2")
+            .unwrap();
+        // Confirm the entry is there.
+        let cached = db.get_dir_cache("/tmp/testdir").unwrap();
+        assert!(cached.is_some(), "expected dir_cache entry before invalidation");
+        // Invalidate.
+        db.invalidate_caches();
+        // Entry should be gone.
+        let cached_after = db.get_dir_cache("/tmp/testdir").unwrap();
+        assert!(
+            cached_after.is_none(),
+            "expected dir_cache entry to be removed after invalidate_caches"
+        );
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -300,8 +300,12 @@ impl Engine {
         Ok(())
     }
 
-    pub fn reindex(&self, path_env: Option<&str>) -> Result<usize> {
-        indexer::reindex_path_commands(&self.db, path_env)
+    pub fn reindex(&self, path_env: Option<&str>, full: bool) -> Result<usize> {
+        indexer::reindex_path_commands(&self.db, path_env, full, false)
+    }
+
+    pub fn invalidate_caches(&self) {
+        self.db.invalidate_caches();
     }
 
     pub fn stats(&self) -> Result<StatsResponse> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -300,8 +300,8 @@ impl Engine {
         Ok(())
     }
 
-    pub fn reindex(&self, path_env: Option<&str>, full: bool) -> Result<usize> {
-        indexer::reindex_path_commands(&self.db, path_env, full, false)
+    pub fn reindex(&self, path_env: Option<&str>, full: bool, skip_existing: bool) -> Result<usize> {
+        indexer::reindex_path_commands(&self.db, path_env, full, skip_existing)
     }
 
     pub fn invalidate_caches(&self) {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -15,7 +15,12 @@ const HELP_TIMEOUT: Duration = Duration::from_millis(350);
 const MAX_DOCS_PER_COMMAND: usize = 80;
 const MAX_DESCRIPTION_LEN: usize = 160;
 
-pub fn reindex_path_commands(db: &AppDb, path_env: Option<&str>) -> Result<usize> {
+pub fn reindex_path_commands(
+    db: &AppDb,
+    path_env: Option<&str>,
+    full: bool,
+    skip_existing: bool,
+) -> Result<usize> {
     let mut seen = BTreeSet::new();
     let path_env = path_env
         .map(ToOwned::to_owned)
@@ -49,7 +54,9 @@ pub fn reindex_path_commands(db: &AppDb, path_env: Option<&str>) -> Result<usize
                     Some(path.to_string_lossy().as_ref()),
                     mtime,
                 )?;
-                maybe_upsert_docs(db, &name, false)?;
+                if !skip_existing || !db.command_has_docs(&name) {
+                    maybe_upsert_docs(db, &name, full)?;
+                }
                 seen.insert(name);
             }
         }
@@ -413,4 +420,112 @@ fn static_docs(command: &str) -> Option<Vec<StoredDoc>> {
         _ => return None,
     };
     Some(docs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn test_db() -> AppDb {
+        AppDb::open(std::path::Path::new(":memory:")).unwrap()
+    }
+
+    /// Verify that skip_existing=false (default mode) always calls maybe_upsert_docs —
+    /// i.e. running reindex twice does not wipe already-indexed commands.
+    #[test]
+    fn skip_existing_false_does_not_wipe_existing_docs() {
+        let db = test_db();
+        let doc = crate::db::StoredDoc {
+            command: "mycmd".into(),
+            item_type: "option".into(),
+            item_value: "--foo".into(),
+            description: "a flag".into(),
+            source: "help".into(),
+        };
+        db.replace_docs_for_command("mycmd", &[doc]).unwrap();
+        assert!(db.command_has_docs("mycmd"));
+
+        // Pass empty path_env to avoid scanning real PATH.
+        reindex_path_commands(&db, Some(""), false, false).unwrap();
+        // mycmd docs were not touched (not in PATH scan).
+        assert!(db.command_has_docs("mycmd"));
+    }
+
+    /// Verify that skip_existing=true avoids re-indexing commands that already have docs.
+    #[test]
+    fn skip_existing_true_preserves_existing_docs() {
+        let db = test_db();
+        let doc = crate::db::StoredDoc {
+            command: "git".into(),
+            item_type: "subcommand".into(),
+            item_value: "fake-subcmd".into(),
+            description: "fake doc".into(),
+            source: "help".into(),
+        };
+        db.replace_docs_for_command("git", &[doc]).unwrap();
+        assert!(db.command_has_docs("git"));
+
+        // Second reindex with skip_existing=true on empty path; the git entry should be intact.
+        reindex_path_commands(&db, Some(""), true, true).unwrap();
+        assert!(db.command_has_docs("git"));
+    }
+
+    /// Verify that reindex_path_commands discovers and upserts executables from a fake PATH dir.
+    #[test]
+    fn indexes_executables_found_in_path() {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = std::path::PathBuf::from(format!("/tmp/shac-indexer-test-{suffix}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("fakecmd");
+        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let db = test_db();
+        let path_env = dir.to_string_lossy().to_string();
+        let count = reindex_path_commands(&db, Some(&path_env), false, false).unwrap();
+        // Should have indexed at least the fake binary.
+        assert!(count >= 1, "expected at least 1 indexed, got {count}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Verify skip_existing guard: a command that already has docs is not re-indexed.
+    #[test]
+    fn skip_existing_skips_already_indexed_command() {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = std::path::PathBuf::from(format!("/tmp/shac-skip-test-{suffix}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("mybin");
+        std::fs::write(&bin, "#!/bin/sh\necho hello\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let db = test_db();
+        // Manually insert a doc for mybin.
+        let doc = crate::db::StoredDoc {
+            command: "mybin".into(),
+            item_type: "option".into(),
+            item_value: "--version".into(),
+            description: "pre-indexed doc".into(),
+            source: "help".into(),
+        };
+        db.replace_docs_for_command("mybin", &[doc]).unwrap();
+        assert!(db.command_has_docs("mybin"));
+
+        // Reindex with skip_existing=true; mybin should still have its doc (not erased).
+        let path_env = dir.to_string_lossy().to_string();
+        reindex_path_commands(&db, Some(&path_env), true, true).unwrap();
+        assert!(
+            db.command_has_docs("mybin"),
+            "pre-indexed doc should survive skip_existing reindex"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/tests/bg_indexer.rs
+++ b/tests/bg_indexer.rs
@@ -123,9 +123,11 @@ fn bg_indexer_populates_commands_table() {
     let stub_path_env = env.path_with_prefix(&stub_dir);
 
     // Spawn daemon with fast BG intervals so the indexer fires within ~1 second.
+    // SHAC_BG_DISABLED=0 opts back in (the default is disabled in test harness).
     // SHAC_BG_SETTLE_SECS=0 removes the 2s startup delay.
     // SHAC_BG_REINDEX_INTERVAL_SECS=1 makes the loop repeat every second.
     let _daemon = env.spawn_daemon_with_extra_env(&[
+        ("SHAC_BG_DISABLED", "0"),
         ("PATH", stub_path_env.as_str()),
         ("SHAC_BG_SETTLE_SECS", "0"),
         ("SHAC_BG_REINDEX_INTERVAL_SECS", "1"),

--- a/tests/bg_indexer.rs
+++ b/tests/bg_indexer.rs
@@ -1,0 +1,81 @@
+// Integration tests for 7.11 (background indexer), 7.5b (invalidate-caches), and
+// 7.5c (reindex --full / --skip-existing CLI flags).
+
+mod support;
+
+// ── 7.5b: invalidate-caches ─────────────────────────────────────────────────
+
+#[test]
+fn invalidate_caches_returns_ok_when_daemon_running() {
+    let env = support::TestEnv::new("invalidate-caches");
+    let _daemon = env.spawn_daemon();
+    let out = support::run_ok(&env, ["invalidate-caches"]);
+    assert!(
+        out.contains("caches invalidated"),
+        "expected 'caches invalidated' in output, got: {out}"
+    );
+}
+
+// ── 7.5c: reindex --full / --skip-existing ───────────────────────────────────
+
+#[test]
+fn reindex_default_flags_succeeds() {
+    let env = support::TestEnv::new("reindex-default");
+    let _daemon = env.spawn_daemon();
+    // Plain `reindex` (no flags) should succeed and return a JSON response.
+    let out = support::run_ok(&env, ["reindex"]);
+    assert!(
+        out.contains("indexed"),
+        "expected 'indexed' in output, got: {out}"
+    );
+}
+
+#[test]
+fn reindex_skip_existing_flag_succeeds() {
+    let env = support::TestEnv::new("reindex-skip");
+    let _daemon = env.spawn_daemon();
+    let out = support::run_ok(&env, ["reindex", "--skip-existing"]);
+    assert!(
+        out.contains("indexed"),
+        "expected 'indexed' in output, got: {out}"
+    );
+}
+
+/// --full runs a full reindex; verify it sends full=true to daemon and gets a valid response.
+/// We restrict PATH to a single small directory so the daemon reindex completes quickly.
+#[test]
+fn reindex_full_flag_succeeds_with_restricted_path() {
+    let env = support::TestEnv::new("reindex-full");
+    let _daemon = env.spawn_daemon();
+    // Use a long enough timeout for the reindex RPC (default 1500ms can be tight on CI).
+    support::run_ok(&env, ["config", "set", "daemon_timeout_ms", "5000"]);
+    // Restrict PATH so the full reindex only scans the shac binary dir — fast.
+    let mut cmd = env.shac_cmd();
+    cmd.env("PATH", env.bin_dir.to_string_lossy().as_ref());
+    cmd.args(["reindex", "--full"]);
+    let out = cmd.output().expect("run shac reindex --full");
+    assert!(
+        out.status.success(),
+        "reindex --full failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("indexed"),
+        "expected 'indexed' in output, got: {stdout}"
+    );
+}
+
+/// --full and --skip-existing are mutually exclusive (enforced by clap).
+#[test]
+fn reindex_full_and_skip_existing_are_mutually_exclusive() {
+    let env = support::TestEnv::new("reindex-conflict");
+    let _daemon = env.spawn_daemon();
+    let mut cmd = env.shac_cmd();
+    cmd.args(["reindex", "--full", "--skip-existing"]);
+    let out = cmd.output().expect("run shac");
+    assert!(
+        !out.status.success(),
+        "expected failure when both --full and --skip-existing are passed"
+    );
+}

--- a/tests/bg_indexer.rs
+++ b/tests/bg_indexer.rs
@@ -3,6 +3,9 @@
 
 mod support;
 
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
 // ── 7.5b: invalidate-caches ─────────────────────────────────────────────────
 
 #[test]
@@ -77,5 +80,89 @@ fn reindex_full_and_skip_existing_are_mutually_exclusive() {
     assert!(
         !out.status.success(),
         "expected failure when both --full and --skip-existing are passed"
+    );
+}
+
+// ── 7.11: background indexer E2E ────────────────────────────────────────────
+
+/// Proves the background indexer thread actually does work.
+///
+/// Strategy:
+/// 1. Create a stub binary `shac-bg-test-stub` in a controlled stub dir.
+/// 2. Launch the daemon with SHAC_BG_SETTLE_SECS=0 and
+///    SHAC_BG_REINDEX_INTERVAL_SECS=1 so the background thread runs almost
+///    immediately without waiting the real 6-hour interval.
+///    PATH is restricted to only the stub dir + the test bin dir so the indexer
+///    finishes quickly.
+/// 3. Poll for up to 5 seconds for the stub binary to appear in `shac complete`
+///    results (it is added to the `commands` table by reindex_path_commands and
+///    surfaces in command-position completions).
+/// 4. Assert the stub is present; fail with a descriptive message if it is not.
+///
+/// Note: the background thread runs `reindex_path_commands` with `full=false`,
+/// which means `parse_help_output` is not called for unknown binaries (they are
+/// not in the safe_default allow-list).  The verifiable side-effect is therefore
+/// the command being added to the `commands` table, not having its docs parsed.
+/// The completion check below relies on the command-position branch in
+/// `Engine::complete` which lists all commands from `list_commands()`.
+#[test]
+fn bg_indexer_populates_commands_table() {
+    let env = support::TestEnv::new("bg-indexer-e2e");
+
+    // Create a stub binary directory with a unique binary name.
+    let stub_dir = env.root.join("stub-bin");
+    fs::create_dir_all(&stub_dir).expect("create stub dir");
+    let stub_name = "shac-bg-test-stub";
+    let stub_path = stub_dir.join(stub_name);
+    fs::write(&stub_path, "#!/bin/sh\necho stub\n").expect("write stub binary");
+    let mut perms = fs::metadata(&stub_path).expect("stub metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&stub_path, perms).expect("chmod stub binary");
+
+    // Build a PATH that includes the stub dir first, plus the test bin dir.
+    let stub_path_env = env.path_with_prefix(&stub_dir);
+
+    // Spawn daemon with fast BG intervals so the indexer fires within ~1 second.
+    // SHAC_BG_SETTLE_SECS=0 removes the 2s startup delay.
+    // SHAC_BG_REINDEX_INTERVAL_SECS=1 makes the loop repeat every second.
+    let _daemon = env.spawn_daemon_with_extra_env(&[
+        ("PATH", stub_path_env.as_str()),
+        ("SHAC_BG_SETTLE_SECS", "0"),
+        ("SHAC_BG_REINDEX_INTERVAL_SECS", "1"),
+    ]);
+
+    // Poll for up to 5 seconds for the stub to appear in completions.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let stub_prefix = &stub_name[..6]; // "shac-b" — enough to be distinctive
+    let found = loop {
+        let mut cmd = env.shac_cmd();
+        cmd.env("PATH", &stub_path_env);
+        cmd.args([
+            "complete",
+            "--shell", "zsh",
+            "--line", stub_prefix,
+            "--cursor", &stub_prefix.len().to_string(),
+            "--cwd", env.root.to_string_lossy().as_ref(),
+            "--format", "json",
+        ]);
+        if let Ok(out) = cmd.output() {
+            if out.status.success() {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                if stdout.contains(stub_name) {
+                    break true;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    };
+
+    assert!(
+        found,
+        "background indexer did not add '{stub_name}' to the commands table within 5s. \
+         Check that SHAC_BG_SETTLE_SECS and SHAC_BG_REINDEX_INTERVAL_SECS env vars \
+         are read by shacd correctly."
     );
 }

--- a/tests/ranking_regression.rs
+++ b/tests/ranking_regression.rs
@@ -35,7 +35,7 @@ fn ranking_regressions_cover_history_transitions_projects_and_runtime_hints() {
 
     let engine = Engine::new(&paths).expect("engine");
     engine
-        .reindex(Some(fake_bin.to_string_lossy().as_ref()), false)
+        .reindex(Some(fake_bin.to_string_lossy().as_ref()), false, false)
         .expect("reindex fake commands");
 
     engine

--- a/tests/ranking_regression.rs
+++ b/tests/ranking_regression.rs
@@ -35,7 +35,7 @@ fn ranking_regressions_cover_history_transitions_projects_and_runtime_hints() {
 
     let engine = Engine::new(&paths).expect("engine");
     engine
-        .reindex(Some(fake_bin.to_string_lossy().as_ref()))
+        .reindex(Some(fake_bin.to_string_lossy().as_ref()), false)
         .expect("reindex fake commands");
 
     engine

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -122,6 +122,10 @@ impl TestEnv {
     /// Spawn the daemon with additional environment variables layered on top of the
     /// standard test environment.  Used by tests that need to override runtime
     /// knobs such as SHAC_BG_REINDEX_INTERVAL_SECS.
+    ///
+    /// The background indexer is disabled by default (`SHAC_BG_DISABLED=1`) to
+    /// prevent SQLite write contention in tests that don't need it.  Pass
+    /// `("SHAC_BG_DISABLED", "0")` in `extra` to opt back in.
     pub fn spawn_daemon_with_extra_env<K, V>(&self, extra: &[(K, V)]) -> TestDaemon
     where
         K: AsRef<std::ffi::OsStr>,
@@ -129,6 +133,10 @@ impl TestEnv {
     {
         let mut command = Command::new(&self.shacd);
         self.apply_env(&mut command);
+        // Disable the background indexer by default to avoid SQLite write
+        // contention in tests.  Individual tests can override this by passing
+        // ("SHAC_BG_DISABLED", "0") in their extra_env.
+        command.env("SHAC_BG_DISABLED", "1");
         for (k, v) in extra {
             command.env(k, v);
         }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -116,8 +116,22 @@ impl TestEnv {
     }
 
     pub fn spawn_daemon(&self) -> TestDaemon {
+        self.spawn_daemon_with_extra_env(&[] as &[(&str, &str)])
+    }
+
+    /// Spawn the daemon with additional environment variables layered on top of the
+    /// standard test environment.  Used by tests that need to override runtime
+    /// knobs such as SHAC_BG_REINDEX_INTERVAL_SECS.
+    pub fn spawn_daemon_with_extra_env<K, V>(&self, extra: &[(K, V)]) -> TestDaemon
+    where
+        K: AsRef<std::ffi::OsStr>,
+        V: AsRef<std::ffi::OsStr>,
+    {
         let mut command = Command::new(&self.shacd);
         self.apply_env(&mut command);
+        for (k, v) in extra {
+            command.env(k, v);
+        }
         let mut child = command
             .stdin(Stdio::null())
             .stdout(Stdio::null())


### PR DESCRIPTION
## Summary

- **§7.11** — `shacd` spawns a detached background thread after startup that calls `reindex` every 6 h, with 2 s settle delay and exponential backoff on errors. Disabled in tests via `SHAC_BG_DISABLED=1`.
- **§7.5b** — `shac reindex --skip-existing` flag wired through RPC payload and engine; skips commands that already have docs in the DB.
- **§7.5c** — `shac invalidate-caches` subcommand drops memoized dir listings, forcing a fresh sweep on next completion.

## Test plan

- [ ] `cargo test --release -p shac` passes (unit + integration)
- [ ] `cargo test --release --test bg_indexer` exercises the 3 new E2E scenarios
- [ ] Background thread visible in `shacd` via `SHAC_BG_DISABLED` guard