### PR TITLE
fix(zsh): preserve tip POSTDISPLAY in n=0 fallback (codex round 6 P1)

### DIFF
--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -614,9 +614,15 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
     if (( total == 0 )); then
       # Even with no candidates, we may have a tip to surface (notably the
       # unknown_command and first-run greeter, both of which fire at n=0).
-      # Render the tip alone via POSTDISPLAY before falling back, so the user
-      # sees it instead of losing it.
-      _shac_render_tip_only
+      # Render the tip alone via POSTDISPLAY, then invoke the original
+      # completer DIRECTLY (skipping _shac_fallback_complete, which calls
+      # _shac_close_menu and clears POSTDISPLAY before the user sees the tip).
+      if [[ -n "$_shac_pending_tip_text" && -z "${SHAC_NO_TIPS:-}" ]]; then
+        _shac_render_tip_only
+        _shac_reset_menu_state
+        zle _shac_orig_expand_or_complete -- "$@"
+        return $?
+      fi
       _shac_fallback_complete
       return $?
     fi


### PR DESCRIPTION
## Summary

Hot-fix for a P1 regression Codex flagged on PR #16 round-6 review (after merge).

The n=0 tip-render path added in #16 (`c7c2f05` + `a209398`) was non-functional in real interactive use:

1. `_shac_tab_widget` reaches `total == 0`
2. Calls `_shac_render_tip_only` → sets `POSTDISPLAY` with the tip line
3. Calls `_shac_fallback_complete`
4. Which calls `_shac_close_menu 0`
5. Which calls `_shac_clear_menu_display` — sets `POSTDISPLAY=""` ← **tip wiped here**
6. Then runs the original expand-or-complete widget

User never saw the tip. Affects `unknown_command` and the first-run greeter.

## Fix

In the `total == 0` + tip branch, skip `_shac_fallback_complete` and instead invoke the original completer directly:

```sh
if [[ -n "$_shac_pending_tip_text" && -z "${SHAC_NO_TIPS:-}" ]]; then
  _shac_render_tip_only
  _shac_reset_menu_state
  zle _shac_orig_expand_or_complete -- "$@"
  return $?
fi
_shac_fallback_complete
return $?
```

`_shac_reset_menu_state` still clears pending state arrays. `POSTDISPLAY` survives — default completer renders below the tip line.

## Test plan

- [ ] `cargo test --test zsh_functions` — existing harness tests still pass (verified locally; harness exercises `_shac_render_menu` directly, not the tab-widget flow, so adding a coverage test would require new harness — out of scope for hot-fix)
- [ ] Manual: install branch, in a fresh shell run `shac index add-command nonexistent-tool` then type `nonexistent-tool <Tab>` — expect `unknown_command` tip footer to appear and persist
- [ ] Manual: in a fresh `~/.cache/shac` run any Tab — expect first-run greeter to appear and persist

## Related

- PR #16 (the discoverability feature merged shortly before this fix)
- Codex round 6 review on PR #16 — this addresses the P1 it flagged
- The P2 from round 6 (`accepted_sources_recent` always empty in `shac suggest`) is being tracked separately for v0.5.1