### PR TITLE
v0.6.1: fix Homebrew bottle publishing (no more source-build toolchain pull)

### DIFF
--- a/.github/scripts/merge_bottle.py
+++ b/.github/scripts/merge_bottle.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Additively upsert one platform's bottle sha256 into the tap Formula/shac.rb.
+
+Run with the current working directory set to the cloned tap repo. Reads
+PLATFORM, SHA and ROOT_URL from the environment. Idempotent: re-running for the
+same platform replaces that platform's line; running for a second platform adds
+to the existing block without clobbering the first. This lets each CI matrix leg
+publish its own bottle independently, so a slow/stuck runner for one platform
+never blocks another platform's users from getting a bottle.
+"""
+import os
+import re
+
+PATH = "Formula/shac.rb"
+
+
+def main() -> None:
+    platform = os.environ["PLATFORM"]
+    sha = os.environ["SHA"]
+    root_url = os.environ["ROOT_URL"]
+    new_line = f'    sha256 cellar: :any_skip_relocation, {platform}: "{sha}"'
+
+    src = open(PATH).read()
+    m = re.search(r"\n  bottle do\n(.*?)\n  end\n", src, flags=re.DOTALL)
+    if m:
+        body = [
+            line
+            for line in m.group(1).split("\n")
+            if line.strip() and f", {platform}:" not in line
+        ]
+        root = [line for line in body if "root_url" in line] or [
+            f'    root_url "{root_url}"'
+        ]
+        shas = sorted(line for line in body if "root_url" not in line) + [new_line]
+        block = "\n  bottle do\n" + "\n".join(root + shas) + "\n  end\n"
+        src = src[: m.start()] + block + src[m.end() :]
+    else:
+        block = f'  bottle do\n    root_url "{root_url}"\n{new_line}\n  end\n'
+        src = src.replace('  license "MIT"\n', '  license "MIT"\n\n' + block, 1)
+
+    open(PATH, "w").write(src)
+    print(f"merged bottle sha for {platform}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -4,122 +4,78 @@ on:
   push:
     tags: ['v*']
 
+# Each platform builds its bottle AND publishes it independently. A slow or
+# stuck runner for one platform (e.g. the Intel macos-13 queue) must never block
+# another platform's users from getting a bottle. Tap-formula writes across the
+# matrix legs are reconciled with pull --rebase + push retry, and each leg only
+# upserts its own sha256 line (see .github/scripts/merge_bottle.py).
 jobs:
   bottle:
-    name: Build bottle (${{ matrix.os }})
+    name: Build & publish bottle (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15   # arm64_sequoia (Apple Silicon)
-          - os: macos-13   # ventura       (Intel)
+          # arm64 bottle built on the OLDEST supported arm64 macOS so Homebrew's
+          # "older bottle on a newer OS" fallback covers sonoma, sequoia AND
+          # tahoe (macOS 26) from a single build.
+          - os: macos-14  # arm64_sonoma (Apple Silicon)
+          - os: macos-13  # ventura (Intel)
 
     steps:
+      - uses: actions/checkout@v4  # for .github/scripts/merge_bottle.py
+
       - uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Install shac from tap for bottling
+      - name: Build bottle from tap
         run: |
           brew tap Neftedollar/shac https://github.com/Neftedollar/homebrew-shac
           brew install --build-bottle Neftedollar/shac/shac
-
-      - name: Create bottle
-        run: |
           brew bottle \
             --json \
             --root-url "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}" \
             Neftedollar/shac/shac
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: bottle-${{ matrix.os }}
-          path: |
-            *.bottle.tar.gz
-            *.bottle.json
-
-  publish:
-    name: Publish bottles & update tap
-    needs: bottle
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-          path: bottles/
-
-      - name: Upload bottles to GitHub Release
+      - name: Upload this platform's bottle to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Wait for release.yml to create the release first
-          for i in $(seq 1 12); do
-            gh release view "${{ github.ref_name }}" \
-              --repo "${{ github.repository }}" &>/dev/null && break
-            echo "Waiting for release... ($i/12)"
-            sleep 10
+          # Release is created by release.yml in parallel; wait for it.
+          for i in $(seq 1 18); do
+            gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" &>/dev/null && break
+            echo "Waiting for release... ($i/18)"; sleep 10
           done
-          gh release upload "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}" \
-            --clobber \
-            bottles/*.bottle.tar.gz
+          gh release upload "${{ github.ref_name }}" --repo "${{ github.repository }}" --clobber ./*.bottle.tar.gz
 
-      - name: Extract bottle hashes from JSON
-        id: hashes
+      - name: Extract this platform's tag + sha
+        id: h
         run: |
-          # Each JSON contains one platform entry; merge into a single block
-          BOTTLE_LINES=""
-          for f in bottles/*.bottle.json; do
-            PLATFORM=$(jq -r '.[].bottle.tags | keys[0]' "$f")
-            SHA=$(jq -r '.[].bottle.tags | .[keys[0]].sha256' "$f")
-            BOTTLE_LINES="${BOTTLE_LINES}    sha256 cellar: :any_skip_relocation, ${PLATFORM}: \"${SHA}\"\n"
-          done
-          echo "lines<<EOF" >> $GITHUB_OUTPUT
-          printf "%b" "$BOTTLE_LINES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          f=$(ls ./*.bottle.json | head -1)
+          echo "platform=$(jq -r '.[].bottle.tags | keys[0]' "$f")" >> "$GITHUB_OUTPUT"
+          echo "sha=$(jq -r '.[].bottle.tags | .[keys[0]].sha256' "$f")" >> "$GITHUB_OUTPUT"
 
-      - name: Update homebrew-shac tap formula
+      - name: Merge this platform's bottle sha into the tap formula
         env:
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          PLATFORM: ${{ steps.h.outputs.platform }}
+          SHA: ${{ steps.h.outputs.sha }}
+          ROOT_URL: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}
         run: |
-          ROOT_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
-
+          MERGE="$GITHUB_WORKSPACE/.github/scripts/merge_bottle.py"
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/Neftedollar/homebrew-shac.git" tap
           cd tap
-
-          python3 - <<PYEOF
-          import re, os
-
-          root_url = os.environ["ROOT_URL"]
-          lines    = """${{ steps.hashes.outputs.lines }}"""
-
-          bottle_block = (
-              "  bottle do\n"
-              f'    root_url "{root_url}"\n'
-              + lines
-              + "  end\n"
-          )
-
-          with open("Formula/shac.rb") as f:
-              src = f.read()
-
-          # Remove any existing bottle block
-          src = re.sub(r"\n  bottle do\b.*?\n  end\n", "\n", src, flags=re.DOTALL)
-
-          # Insert after the license line
-          src = src.replace(
-              '  license "MIT"\n',
-              '  license "MIT"\n\n' + bottle_block,
-          )
-
-          with open("Formula/shac.rb", "w") as f:
-              f.write(src)
-          PYEOF
-
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add Formula/shac.rb
-          git commit -m "chore: add bottles for ${{ github.ref_name }}"
-          git push
+          for attempt in 1 2 3 4 5; do
+            git pull --rebase --autostash origin HEAD || true
+            python3 "$MERGE"
+            git add Formula/shac.rb
+            git commit -m "chore: bottle ${PLATFORM} for ${{ github.ref_name }}" || { echo "nothing to commit"; exit 0; }
+            if git push; then echo "pushed ${PLATFORM}"; exit 0; fi
+            echo "push race, retrying ($attempt)"; sleep $((RANDOM % 5 + 2))
+          done
+          echo "failed to update tap after retries"; exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.6.1 — 2026-07-06
+
+### Fixed
+- Homebrew installs now use a pre-built bottle instead of compiling from source.
+  The bottle-publish CI blocked on a single slow runner (one platform's queue
+  stalled the tap update for everyone), so `brew install/upgrade shac` fell back
+  to `cargo install`, which drags in the whole Rust + LLVM toolchain (~600 MB:
+  llvm, rust, z3, python, libgit2, openssl) that shac never needs at runtime.
+  Bottles are now built and published per-platform independently, the arm64
+  bottle is built on the oldest supported macOS so it covers sonoma/sequoia/
+  tahoe, and the tap formula merges each platform's sha additively.
+
 ## v0.6.0 — 2026-07-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"


### PR DESCRIPTION
**v0.6.1 — packaging hotfix.** No runtime code change from v0.6.0.

### Problem
The Homebrew bottle-publish CI (`bottle.yml`) had `publish` depend on the *entire* build matrix. When one platform's runner was slow/queued (the Intel `macos-13` leg), the tap-formula update never ran — so during that window the tap had **no `bottle do` block**, and `brew install/upgrade shac` fell back to `cargo install`. That drags in the whole Rust + LLVM toolchain (~600 MB: llvm, rust, z3, python, libgit2, openssl) that shac never needs at runtime. Worse, a partial toolchain upgrade (z3 bumped, llvm not) can break the host's `rustc` via the llvm↔z3 ABI.

### Fix
- Each platform now **builds AND publishes its own bottle independently** — a stuck Intel runner no longer blocks Apple Silicon users.
- The arm64 bottle is built on the **oldest supported arm64 macOS** (`macos-14`, sonoma) so Homebrew's older-bottle fallback covers sonoma / sequoia / **tahoe (macOS 26)** from one build.
- Each leg upserts only its own `sha256` line into the tap formula via `.github/scripts/merge_bottle.py` (reconciled with `pull --rebase` + push retry). The merge script is unit-tested for additive + idempotent behavior.

### Verification
The bottle publishing itself can only be fully validated by the `v0.6.1` tag build (CI cannot exercise the tap push). The merge script's additive/idempotent logic was tested locally. No Rust source changed, so the code is identical to the green v0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
