### PR TITLE
release: v0.6.3 — genuine universal macOS binary (lipo)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,26 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build release binaries
-        run: cargo build --release --bins
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            # macos-latest is Apple Silicon; a plain build is arm64-only. Build
+            # both Apple targets and lipo them into one genuinely universal
+            # binary so the shac-macos-universal asset runs on Intel Macs too.
+            rustup target add aarch64-apple-darwin x86_64-apple-darwin
+            cargo build --release --bins --target aarch64-apple-darwin
+            cargo build --release --bins --target x86_64-apple-darwin
+            mkdir -p target/release
+            for b in shac shacd; do
+              lipo -create -output "target/release/$b" \
+                "target/aarch64-apple-darwin/release/$b" \
+                "target/x86_64-apple-darwin/release/$b"
+            done
+            file target/release/shac target/release/shacd
+          else
+            cargo build --release --bins
+          fi
 
       - name: Package
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.6.3 — 2026-07-08
+
+### Fixed
+- **The `shac-macos-universal` asset is now a genuine universal binary.** It was
+  built with a plain `cargo build` on an Apple Silicon runner, so it was
+  arm64-only despite the name — fine on Apple Silicon, but the v0.6.2 binary
+  formula would hand that arm64 binary to Intel Macs, where it cannot run.
+  Release CI now builds both `aarch64-apple-darwin` and `x86_64-apple-darwin`
+  and `lipo`-merges them into one fat binary, so `brew install` works on both
+  Apple Silicon and Intel Macs.
+
 ## v0.6.2 — 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/Formula/shac.rb
+++ b/Formula/shac.rb
@@ -14,13 +14,13 @@ class Shac < Formula
   # The url/sha256 committed here are the last-released values and serve as the
   # rendering template; they are not consumed by a normal tap install.
   on_macos do
-    url "https://github.com/Neftedollar/sh-autocomplete/releases/download/v0.6.1/shac-macos-universal.tar.gz"
-    sha256 "5ef3e6d43e568b0fd539ceb538cc78f1873739ba8572a29a5cbc3f722e7ee297"
+    url "https://github.com/Neftedollar/sh-autocomplete/releases/download/v0.6.2/shac-macos-universal.tar.gz"
+    sha256 "1798f39474a7c722142b8437a6870836ee391f35997bf92f89469ba3b1c85810"
   end
 
   on_linux do
-    url "https://github.com/Neftedollar/sh-autocomplete/releases/download/v0.6.1/shac-linux-x86_64.tar.gz"
-    sha256 "a836577e6686f217a189376b9cadbf2b81299b2cd0184993ec64d5d6b6378263"
+    url "https://github.com/Neftedollar/sh-autocomplete/releases/download/v0.6.2/shac-linux-x86_64.tar.gz"
+    sha256 "6519a5d619f4b2d62319169fcfbf59edf712a91bdc08e725f7a82df68006633d"
   end
 
   # `brew install --HEAD shac` still builds from source; only that opt-in path


### PR DESCRIPTION
## What

The `shac-macos-universal` release asset was built with a plain `cargo build` on an Apple Silicon runner — so it was **arm64-only despite the name**. The v0.6.2 binary-install formula hands that prebuilt binary to *every* Mac, so an Intel Mac would download an arm64 binary it cannot execute. (The old source-build formula sidestepped this by compiling per-host.)

## Fix

Release CI now builds **both** `aarch64-apple-darwin` and `x86_64-apple-darwin` and `lipo`-merges them into one genuinely universal binary. `file` verification of the merged binary is printed in the build log. Apple Silicon and Intel Macs both get a runnable binary.

Also refreshes the repo formula's committed template url+sha to the real v0.6.2 values (the tap is still rendered by CI at tag time; this just keeps `brew install ./Formula/shac.rb` internally consistent).

## Note

v0.6.2 already fully resolves the toolchain-bloat problem on Apple Silicon; this closes the Intel-Mac gap the "universal" label implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)