### PR TITLE
fix: forward-compatible adapter + stale-adapter detection (v0.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.6.5 — 2026-07-08
+
+### Fixed
+- **Phantom blank completion after upgrade.** v0.6.4 made `shac complete` emit a
+  new `__shac_client_version` protocol line, but `brew upgrade` refreshes the
+  binary without re-running `shac install`, so the still-installed older zsh
+  adapter did not recognize the line and mis-parsed it as a completion candidate
+  — a blank menu entry whose insertion was the version string (`cd 0.6.4`).
+  - Reverted the `__shac_client_version` emission and the widget's live parse of
+    it; stale-daemon detection already lives in the `shac doctor daemon_version`
+    check (v0.6.4), which needs no protocol change.
+  - The zsh adapter now **ignores any unrecognized `__shac_*` control line**
+    instead of rendering it as a candidate, so a future binary can add protocol
+    lines without breaking an older adapter.
+- **Stale-adapter detection.** `shac doctor` gains a `zsh_adapter_current` check
+  that compares the installed adapter against the one embedded in this binary
+  and tells you to run `shac install --shell zsh` when a `brew upgrade` left it
+  outdated (the adapter counterpart to the `daemon_version` check).
+
 ## v0.6.4 — 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -702,13 +702,13 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
         local -a dv_fields
         dv_fields=("${(ps:\t:)line}")
         _shac_daemon_version="${dv_fields[2]:-}"
-      elif [[ "$line" == __shac_client_version$'\t'* ]]; then
-        # Refresh the client version from the live binary on every fetch so a
-        # stale daemon is detected even when `shac shell-env` was not re-sourced
-        # after an upgrade (see _shac_check_version_mismatch).
-        local -a cv_fields
-        cv_fields=("${(ps:\t:)line}")
-        _shac_client_version="${cv_fields[2]:-}"
+      elif [[ "$line" == __shac_*$'\t'* ]]; then
+        # Unknown control line from a newer binary (an added __shac_* protocol
+        # line). Ignore it: the else branch below would otherwise treat it as a
+        # completion candidate and surface a blank phantom item whose insert_text
+        # is the control payload. Forward compatibility -- a newer binary may add
+        # __shac_* lines without this adapter mis-rendering them.
+        continue
       else
         local -a fields
         fields=("${(ps:\t:)line}")

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -856,6 +856,7 @@ fn doctor(paths: &AppPaths, args: DoctorArgs) -> Result<()> {
             paths.shell_dir.join("shac.zsh").exists(),
             paths.shell_dir.join("shac.zsh").display().to_string(),
         ),
+        adapter_currency_check(paths),
         doctor_check(
             "bash_adapter",
             paths.shell_dir.join("shac.bash").exists(),
@@ -1069,6 +1070,33 @@ fn adapter_contains_owned_widget(path: &Path) -> bool {
             content.contains("_shac_tab_widget") && content.contains("_shac_space_widget")
         })
         .unwrap_or(false)
+}
+
+/// Doctor check: the installed zsh adapter must match the one embedded in this
+/// binary. `brew upgrade` refreshes the binary but not the adapter that
+/// `shac install` wrote to the config dir, so a stale adapter can mis-parse a
+/// newer binary's output (e.g. render an unrecognized control line as a blank
+/// phantom candidate). Only a present-but-outdated adapter fails; a missing one
+/// is left to the `zsh_adapter` existence check.
+fn adapter_currency_check(paths: &AppPaths) -> serde_json::Value {
+    let path = paths.shell_dir.join("shac.zsh");
+    if !path.exists() {
+        return doctor_check(
+            "zsh_adapter_current",
+            true,
+            "no zsh adapter installed".to_string(),
+        );
+    }
+    let current = fs::read_to_string(&path)
+        .map(|content| content == ZSH_COMPLETION)
+        .unwrap_or(false);
+    let detail = if current {
+        "matches installed binary".to_string()
+    } else {
+        "stale — run `shac install --shell zsh` (a `brew upgrade` does not refresh the adapter)"
+            .to_string()
+    };
+    doctor_check("zsh_adapter_current", current, detail)
 }
 
 fn command_available(command: &str) -> bool {
@@ -1840,14 +1868,6 @@ fn print_completion_response(
         if let Some(dv) = response.get("daemon_version").and_then(|v| v.as_str()) {
             println!("__shac_daemon_version\t{}", encode_field(dv));
         }
-        // Emit the client's own version on every response so the widget can
-        // detect a stale daemon live, without depending on `shac shell-env`
-        // having been re-sourced after an upgrade (a bare `brew upgrade` in an
-        // existing shell would otherwise leave _shac_client_version empty).
-        println!(
-            "__shac_client_version\t{}",
-            encode_field(env!("CARGO_PKG_VERSION"))
-        );
     } else {
         let items = response
             .get("items")


### PR DESCRIPTION
## The bug

Dogfooding v0.6.4: `cd <Tab>` showed a **blank 13th menu entry**, and selecting it put `cd 0.6.4` on the command line.

**Root cause (a backward-compat mistake I shipped in v0.6.4):** v0.6.4 made `shac complete` emit a new `__shac_client_version` protocol line. But `brew upgrade` refreshes the binary **without** re-running `shac install`, so the still-installed older zsh adapter didn't recognize the line — its `else` branch treated it as a completion candidate, producing a blank phantom whose `insert_text` was the version string.

## Fixes

- **Revert the `__shac_client_version` emission** (`shac.rs`) and the widget's live parse of it (`shac.zsh`). Stale-daemon detection already lives in the `shac doctor daemon_version` check (v0.6.4) and needs no protocol change.
- **Adapter ignores unrecognized `__shac_*` control lines** instead of rendering them as candidates — a newer binary can now add protocol lines without breaking an older adapter (forward compatibility).
- **New `shac doctor` check `zsh_adapter_current`** — compares the installed adapter to the one embedded in this binary and tells you to run `shac install --shell zsh` when a `brew upgrade` left it stale (the adapter counterpart to `daemon_version`).

## Validation (local, toolchain repaired)

fmt + clippy + full test suite + `zsh -n`, plus E2E:
- new binary no longer emits `__shac_client_version`;
- the `__shac_*` guard skips a control line (`[[ "$line" == __shac_*$'\t'* ]]` → continue);
- `shac doctor` → `zsh_adapter_current  fail  stale — run shac install --shell zsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)