### PR TITLE
fix: flag-as-argument completion + document index/daemon subcommands (v0.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.6.7 — 2026-07-08
+
+### Fixed
+- **A flag typed as an argument no longer completes as `./--flag`.** A history
+  entry like `bash --help` was offered for `bash <Tab>` as a `subcommand`
+  candidate, and since a real subcommand never starts with `-`, the leading-dash
+  path guard rewrote it to `bash ./--help` (which fails). Flag-shaped history/
+  transition arguments are now classified as options, so they insert bare.
+- **`shac index`/`shac daemon` subcommands were undocumented.** `shac index
+  --help` listed `add-command` / `add-path` / `status` with blank descriptions;
+  those (and the `daemon` start/stop/restart/status verbs) now carry help text.
+
 ## v0.6.6 — 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -285,26 +285,38 @@ struct IndexArgs {
 
 #[derive(Debug, Subcommand)]
 enum IndexAction {
+    /// Index a command's flags and subcommands from its `--help` output
     AddCommand {
+        /// Command name to index (e.g. git, cargo, docker)
         cmd: String,
     },
+    /// Index a directory's paths so they complete for `cd` and friends
     AddPath {
+        /// Directory to index
         path: String,
+        /// Also index one level of subdirectories
         #[arg(long)]
         subpath: bool,
+        /// Index the full recursive tree (may be slow for large trees)
         #[arg(long)]
         full: bool,
+        /// Recursion depth when indexing subdirectories (0 = unlimited)
         #[arg(long, default_value_t = 0)]
         deep: usize,
     },
+    /// Show what has been indexed (commands, paths, docs)
     Status,
 }
 
 #[derive(Debug, Subcommand)]
 enum DaemonAction {
+    /// Start the background daemon
     Start,
+    /// Stop the running daemon
     Stop,
+    /// Restart the daemon (reload the current binary)
     Restart,
+    /// Show whether the daemon is running
     Status,
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2662,11 +2662,19 @@ fn project_history_candidate(
         return None;
     }
     let token = tokens.get(parsed.active_index)?.to_string();
-    let kind = match parsed.role {
-        TokenRole::Option => "option",
-        TokenRole::Path => "path",
-        TokenRole::SubcommandOrArg => "subcommand",
-        TokenRole::Command => "history",
+    // A flag the user typed as an argument (e.g. `bash --help`) lands in
+    // SubcommandOrArg position, but a real subcommand never starts with `-`.
+    // Classify it as an option so it inserts bare instead of getting the
+    // leading-dash `./` path guard (which would yield the broken `bash ./--help`).
+    let kind = if token.starts_with('-') {
+        "option"
+    } else {
+        match parsed.role {
+            TokenRole::Option => "option",
+            TokenRole::Path => "path",
+            TokenRole::SubcommandOrArg => "subcommand",
+            TokenRole::Command => "history",
+        }
     };
     let display = sanitize_display(&token);
     Some((token, display, kind.to_string()))
@@ -3313,6 +3321,35 @@ mod tests {
             contextual_candidate_key(&parsed, &candidate),
             "git checkout"
         );
+    }
+
+    #[test]
+    fn project_history_candidate_classifies_flag_arg_as_option() {
+        let parsed = ParsedContext {
+            line_before_cursor: "bash ".to_string(),
+            tokens: vec!["bash".to_string(), String::new()],
+            active_token: String::new(),
+            active_index: 1,
+            role: TokenRole::SubcommandOrArg,
+            command: Some("bash".to_string()),
+            prev_token: Some("bash".to_string()),
+            project_markers: Vec::new(),
+            open_quote: None,
+        };
+
+        // `bash --help` from history: --help is a flag, not a subcommand, so it
+        // must be kind "option" -- otherwise the leading-dash `./` path guard
+        // turns it into the broken `bash ./--help` on accept.
+        let (token, _display, kind) =
+            project_history_candidate("bash --help", &parsed).expect("flag candidate");
+        assert_eq!(token, "--help");
+        assert_eq!(kind, "option");
+
+        // A non-flag argument keeps its role-based classification.
+        let (token, _display, kind) =
+            project_history_candidate("bash script.sh", &parsed).expect("arg candidate");
+        assert_eq!(token, "script.sh");
+        assert_eq!(kind, "subcommand");
     }
 
     fn unique_tmp(prefix: &str) -> std::path::PathBuf {


### PR DESCRIPTION
Two fixes from continued dogfooding.

## 1. `bash <Tab>` → `bash ./--help` (broken)

A history entry `bash --help` was offered for `bash <Tab>` as a **`subcommand`** candidate — `project_history_candidate` assigns `kind` purely by token position (`SubcommandOrArg => "subcommand"`). But a real subcommand never starts with `-`, so `quote_token`'s leading-dash `./` path guard rewrote `--help` to `./--help`, and `bash ./--help` fails.

Fix: a `-`-leading argument is now classified as an **option**, so `is_option` is true and it inserts bare (`bash --help`). This routes through both the history and transition candidate paths.

## 2. `shac index` / `shac daemon` subcommands were undocumented

`shac index --help` listed `add-command` / `add-path` / `status` with **blank descriptions** (the clap `IndexAction` enum had no doc comments); same for `daemon` start/stop/restart/status. Added help text — which also enriches shac's own indexed subcommand docs.

## Validation

fmt + clippy + full suite (346 tests, +1 new `project_history_candidate_classifies_flag_arg_as_option`). The E2E daemon swap is blocked by launchd (`brew services` `keep_alive` respawns the production daemon), so the flag-arg fix is proven by the unit test plus the established `is_option → quote_token` skip-`./` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)