### PR TITLE
fix: trim history candidates so trailing-whitespace dupes dedup (v0.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.6.9 — 2026-07-08
+
+### Fixed
+- **Duplicate rows in completion menus.** A history line stored with trailing
+  whitespace (e.g. `clr `) produced a candidate whose `insert_text` differed
+  from the clean `clr` only by an invisible space, so dedup-by-insert_text let
+  both through and the menu showed two identical-looking rows (one "Provided by
+  current shell context", one "Previously executed command"). History,
+  runtime-history and transition candidates are now trimmed before dedup.
+
 ## v0.6.8 — 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2711,6 +2711,10 @@ fn project_history_candidate(
     entry: &str,
     parsed: &ParsedContext,
 ) -> Option<(String, String, String)> {
+    // Trailing/leading whitespace in a stored history line (e.g. `clr `) would
+    // otherwise yield a candidate distinct from `clr`, escaping dedup-by-
+    // insert_text and rendering as an invisible duplicate menu row.
+    let entry = entry.trim();
     if matches!(parsed.role, TokenRole::Command) {
         return Some((
             entry.to_string(),
@@ -3412,6 +3416,28 @@ mod tests {
             project_history_candidate("bash script.sh", &parsed).expect("arg candidate");
         assert_eq!(token, "script.sh");
         assert_eq!(kind, "subcommand");
+    }
+
+    #[test]
+    fn project_history_candidate_trims_whitespace_so_dupes_dedup() {
+        let parsed = ParsedContext {
+            line_before_cursor: "clr".to_string(),
+            tokens: vec!["clr".to_string()],
+            active_token: "clr".to_string(),
+            active_index: 0,
+            role: TokenRole::Command,
+            command: None,
+            prev_token: None,
+            project_markers: Vec::new(),
+            open_quote: None,
+        };
+        // A stored history line with a trailing space must produce the same
+        // insert_text as the clean form, so both collapse to one row under
+        // dedup-by-insert_text (no invisible duplicate `clr ` vs `clr`).
+        let (with_space, _, _) = project_history_candidate("clr ", &parsed).unwrap();
+        let (clean, _, _) = project_history_candidate("clr", &parsed).unwrap();
+        assert_eq!(with_space, "clr");
+        assert_eq!(with_space, clean);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`clr<Tab>` showed **two identical-looking `clr` rows** — one "Provided by current shell context" (runtime_history), one "Previously executed command" (history).

## Root cause

A history line was stored with a trailing space (`clr `). `project_history_candidate` returned it verbatim as the Command-position candidate, so its `insert_text` was `clr ` — distinct from the clean runtime `clr` by only an invisible trailing space. `push_candidate` dedups by `insert_text`, so the two didn't merge and both rendered (the trailing space is invisible in the menu).

## Fix

`project_history_candidate` now `trim()`s the entry up front. This covers the history, runtime-history **and** transition candidate paths (all route through this function), so `clr ` collapses onto `clr` under dedup. Genuinely different commands (`clr --resume`, `clr resume`, …) are unaffected.

## Validation

fmt + clippy + full suite (348 tests, +1 `project_history_candidate_trims_whitespace_so_dupes_dedup`). E2E via a debug daemon: `clr` now appears once with a runtime `clr` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)