### PR TITLE
fix: Fable-review batch — correctness + completion usability (v0.6.10)

### DIFF
--- a/.github/scripts/render_tap_formula.py
+++ b/.github/scripts/render_tap_formula.py
@@ -24,6 +24,12 @@ REPO = "Neftedollar/sh-autocomplete"
 
 def patch_platform(src: str, os_kw: str, filename: str, tag: str, sha: str) -> str:
     """Replace the url + sha256 inside a single `on_<os_kw> do ... end` block."""
+    # Last gate before the tap: refuse to render an empty/garbage sha256, which
+    # would ship a formula that fails every `brew install` with a checksum error.
+    if not re.fullmatch(r"[0-9a-f]{64}", sha):
+        raise SystemExit(
+            f"render_tap_formula: {os_kw} sha256 is not 64 hex chars: {sha!r}"
+        )
     url = f"https://github.com/{REPO}/releases/download/{tag}/{filename}"
 
     def repl(match: "re.Match[str]") -> str:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,13 @@ jobs:
             echo "asset ${name} never became available" >&2
             return 1
           }
-          echo "macos=$(fetch_sha shac-macos-universal.tar.gz)" >> "$GITHUB_OUTPUT"
-          echo "linux=$(fetch_sha shac-linux-x86_64.tar.gz)" >> "$GITHUB_OUTPUT"
+          # Plain assignment (not `echo "x=$(...)"`): a command-substitution
+          # failure inside an echo argument does NOT fail the step under
+          # `set -e` — echo's own exit 0 wins — which would ship `sha256 ""`.
+          macos_sha=$(fetch_sha shac-macos-universal.tar.gz)
+          linux_sha=$(fetch_sha shac-linux-x86_64.tar.gz)
+          echo "macos=${macos_sha}" >> "$GITHUB_OUTPUT"
+          echo "linux=${linux_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout homebrew-shac tap
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v0.6.10 — 2026-07-11
+
+Fixes from a three-lens Fable review (engine, release pipeline, usability).
+
+### Fixed — correctness
+- **Accepting a full command line from history no longer runs broken escaped
+  text.** A row like `cd ..` was inserted token-escaped (`cd\ ..`) and executed
+  as a single word (`command not found: cd ..`), which then re-poisoned the
+  history. Whole command lines (multi-word `history`/`command` candidates) now
+  insert raw; single tokens (paths, options) are still escaped.
+- **`cd <Tab>` no longer suggests deleted directories via a kind hole.** The
+  v0.6.8 existence filter only ran for `kind == "path"`, but single-segment
+  history tokens arrive as `subcommand`; every cd-argument candidate is now
+  existence-checked. The check is also hardened: `$VAR`/`~user`/glob tokens and
+  absolute paths outside `$HOME` (possible dead network mounts) are kept rather
+  than stat'd, and it uses `is_dir`.
+- **`--help`/man option parsing** — a metavar between flags no longer drops the
+  long form (`-o FILE, --output FILE` → both), and `--color[=WHEN]` / `-i[SUFFIX]`
+  no longer produce corrupt `--color[` tokens. The man-page doc cap actually
+  bounds output again (a mis-scoped `break` had disabled it).
+- **`doc_search` is scoped to the current command** — `git c<Tab>` no longer
+  leaks mdfind's `-case_sensitive` etc.; doc `insert_text` is stripped of control
+  bytes (roff overstrike) so accepting never injects them into the buffer.
+- **Release pipeline can't ship an empty checksum** — an asset-sha fetch failure
+  now fails the job (plain assignment vs `echo "$(...)"`), and the tap renderer
+  refuses any sha256 that isn't 64 hex chars.
+- **`shac doctor` version probe** is read-only (`SHAC_NO_TIPS`, so it no longer
+  burns the one-shot first-run greeter) and now flags a pre-0.5.2 daemon that
+  answers without a version field instead of waving it through.
+
+### Fixed — usability (ranking & noise)
+- **Transitions ("what you run after X") only appear at command position** — no
+  more `git c<Tab>` → `clr`, or a once-pasted sentence offered as an argument.
+- **Subcommand indexing** now reads aliased rows (cargo's `build, b` → `build`)
+  and underscore names (`s_client`).
+- **Git branch completion** collapses each `origin/foo` twin when the local
+  `foo` exists and drops the bare `origin` remote name.
+- **Path completion is case-insensitive** — `cd d<Tab>` surfaces
+  `Documents/`/`Desktop/` on a case-insensitive macOS filesystem.
+- Redundant per-row descriptions ("Previously executed command", "Provided by
+  current shell context", "Frequently used after X") are dropped as clutter.
+
 ## v0.6.9 — 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -973,7 +973,7 @@ fn daemon_version_check(paths: &AppPaths) -> serde_json::Value {
         );
     }
     let daemon = probe_daemon_version(paths);
-    let (ok, detail) = version_skew_detail(client, daemon.as_deref());
+    let (ok, detail) = version_skew_detail(client, &daemon);
     doctor_check("daemon_version", ok, detail)
 }
 
@@ -982,17 +982,38 @@ fn daemon_version_check(paths: &AppPaths) -> serde_json::Value {
 /// mismatch is a failure; an unreadable version (probe error/timeout) stays OK
 /// so a transient hiccup doesn't cry wolf — `daemon_running` already covers
 /// connectivity.
-fn version_skew_detail(client: &str, daemon: Option<&str>) -> (bool, String) {
+/// Outcome of probing the running daemon for its version.
+enum DaemonVersionProbe {
+    /// The daemon reported its version.
+    Version(String),
+    /// The daemon answered but the response carried no `daemon_version` field —
+    /// definitionally a pre-0.5.2 daemon (the field has shipped since v0.5.2),
+    /// i.e. exactly the stale daemon this check exists to catch.
+    MissingField,
+    /// Could not reach or decode the daemon (connect, timeout, or parse error).
+    Unreachable,
+}
+
+fn version_skew_detail(client: &str, daemon: &DaemonVersionProbe) -> (bool, String) {
     match daemon {
-        Some(d) if d == client => (true, format!("client and daemon both v{client}")),
-        Some(d) => (
+        DaemonVersionProbe::Version(d) if d == client => {
+            (true, format!("client and daemon both v{client}"))
+        }
+        DaemonVersionProbe::Version(d) => (
             false,
             format!(
                 "daemon v{d} still running but client is v{client} — run `shac daemon restart` \
                  (`brew upgrade` leaves the old daemon in memory)"
             ),
         ),
-        None => (
+        DaemonVersionProbe::MissingField => (
+            false,
+            format!(
+                "a pre-0.5.2 daemon is still running (client is v{client}) — run \
+                 `shac daemon restart`"
+            ),
+        ),
+        DaemonVersionProbe::Unreachable => (
             true,
             format!("client v{client}; could not read running daemon version"),
         ),
@@ -1000,15 +1021,20 @@ fn version_skew_detail(client: &str, daemon: Option<&str>) -> (bool, String) {
 }
 
 /// Ask the running daemon for its version via a minimal read-only `complete`
-/// probe (the only action whose response carries `daemon_version`). Returns
-/// None on any connect/timeout/parse error.
-fn probe_daemon_version(paths: &AppPaths) -> Option<String> {
+/// probe (the only action whose response carries `daemon_version`). Distinguishes
+/// a genuinely absent version field (old daemon) from an unreachable daemon.
+fn probe_daemon_version(paths: &AppPaths) -> DaemonVersionProbe {
+    let mut env = std::collections::HashMap::new();
+    // Keep the probe read-only: SHAC_NO_TIPS stops the daemon claiming the
+    // one-shot first-run greeter or advancing tip-cooldown state for this
+    // throwaway request (maybe_pick_tip gates on it).
+    env.insert("SHAC_NO_TIPS".to_string(), "1".to_string());
     let req = CompletionRequest {
         shell: "zsh".to_string(),
         line: String::new(),
         cursor: 0,
         cwd: ".".to_string(),
-        env: std::collections::HashMap::new(),
+        env,
         session: SessionInfo {
             tty: None,
             pid: None,
@@ -1018,16 +1044,25 @@ fn probe_daemon_version(paths: &AppPaths) -> Option<String> {
             runtime_commands: Vec::new(),
         },
     };
-    let payload = serde_json::to_value(req).ok()?;
+    let payload = match serde_json::to_value(req) {
+        Ok(payload) => payload,
+        Err(_) => return DaemonVersionProbe::Unreachable,
+    };
     // A generous one-shot timeout: unlike a live completion this is a manual
     // diagnostic, and the production `daemon_timeout_ms` (tens of ms) is too
     // tight for the empty-line probe, which triggers a full candidate compute.
     let response =
-        send_request_with_timeout(paths, "complete", payload, Duration::from_millis(1000)).ok()?;
-    response
+        match send_request_with_timeout(paths, "complete", payload, Duration::from_millis(1000)) {
+            Ok(response) => response,
+            Err(_) => return DaemonVersionProbe::Unreachable,
+        };
+    match response
         .get("daemon_version")
         .and_then(|value| value.as_str())
-        .map(|value| value.to_string())
+    {
+        Some(version) => DaemonVersionProbe::Version(version.to_string()),
+        None => DaemonVersionProbe::MissingField,
+    }
 }
 
 fn zsh_doctor_checks(paths: &AppPaths) -> Result<Vec<serde_json::Value>> {
@@ -1859,7 +1894,19 @@ fn print_completion_response(
                 .and_then(|value| value.as_str())
                 .unwrap_or_default();
             let item_ctx = item_token_context(&ctx, typed_home_user, &item);
-            let quoted_insert = quote_token(shell, &item_ctx, insert_text);
+            // A whole command line resurrected from history/transitions (kind
+            // `history`/`command`, multi-word) replaces the buffer and is
+            // already valid shell — per-token escaping would turn `cd ..` into
+            // `cd\ ..` (one broken word that executes as "command not found: cd
+            // .."). Single-token candidates (paths, options, subcommands) are
+            // still escaped. Mirrors the widget's `_shac_selected_is_full_line`.
+            let is_full_line_command =
+                matches!(kind, "history" | "command") && item_key.contains(' ');
+            let quoted_insert = if is_full_line_command {
+                insert_text.to_string()
+            } else {
+                quote_token(shell, &item_ctx, insert_text)
+            };
             println!(
                 "{}\t{}\t{}\t{}\t{}\t{}",
                 encode_field(item_key),
@@ -2522,20 +2569,28 @@ mod completion_response_tests {
     #[test]
     fn version_skew_detail_flags_only_confirmed_mismatch() {
         // Matching versions: ok, no alarm.
-        let (ok, _) = version_skew_detail("0.6.4", Some("0.6.4"));
+        let (ok, _) =
+            version_skew_detail("0.6.4", &DaemonVersionProbe::Version("0.6.4".to_string()));
         assert!(ok);
 
         // Confirmed mismatch (stale daemon after brew upgrade): fail, and the
         // detail must tell the user exactly how to fix it.
-        let (ok, detail) = version_skew_detail("0.6.4", Some("0.5.3"));
+        let (ok, detail) =
+            version_skew_detail("0.6.4", &DaemonVersionProbe::Version("0.5.3".to_string()));
         assert!(!ok);
         assert!(detail.contains("0.5.3"));
         assert!(detail.contains("0.6.4"));
         assert!(detail.contains("shac daemon restart"));
 
-        // Unreadable version (probe timeout/error): stays OK so a transient
-        // hiccup doesn't cry wolf.
-        let (ok, _) = version_skew_detail("0.6.4", None);
+        // A daemon that answers but omits the version field is a confirmed
+        // pre-0.5.2 daemon — fail, don't wave it through.
+        let (ok, detail) = version_skew_detail("0.6.4", &DaemonVersionProbe::MissingField);
+        assert!(!ok);
+        assert!(detail.contains("shac daemon restart"));
+
+        // Unreachable (probe timeout/error): stays OK so a transient hiccup
+        // doesn't cry wolf.
+        let (ok, _) = version_skew_detail("0.6.4", &DaemonVersionProbe::Unreachable);
         assert!(ok);
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -453,19 +453,22 @@ impl AppDb {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
-    pub fn search_docs(&self, query: &str, limit: usize) -> Result<Vec<StoredDoc>> {
+    pub fn search_docs(&self, command: &str, query: &str, limit: usize) -> Result<Vec<StoredDoc>> {
         // FTS5 treats special chars (. * ^ " etc.) as syntax; wrap in double
         // quotes and escape internal quotes so arbitrary prefixes don't error.
         let escaped = query.replace('"', "\"\"");
         let fts_query = format!("\"{escaped}\"*");
+        // Scope to the current command: without the `d.command = ?` filter the
+        // FTS matched every command's docs, so `git c<Tab>` surfaced mdfind's
+        // `-case_sensitive`, another tool's mangled roff, etc.
         let mut stmt = self.conn.prepare(
             "SELECT d.command, d.item_type, d.item_value, d.description, d.source
              FROM command_docs_fts f
              JOIN command_docs d ON d.id = f.rowid
-             WHERE command_docs_fts MATCH ?1
-             LIMIT ?2",
+             WHERE command_docs_fts MATCH ?1 AND d.command = ?2
+             LIMIT ?3",
         )?;
-        let rows = stmt.query_map(params![fts_query, limit as i64], |row| {
+        let rows = stmt.query_map(params![fts_query, command, limit as i64], |row| {
             Ok(StoredDoc {
                 command: row.get(0)?,
                 item_type: row.get(1)?,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -527,8 +527,10 @@ impl Engine {
                 if let Some((insert_text, display, kind)) =
                     project_history_candidate(command, parsed)
                 {
-                    let stale_cd_path = kind == "path"
-                        && is_cd_path_context(parsed)
+                    // In a cd context EVERY argument is a directory, whatever
+                    // `kind` the source assigned (single-segment tokens come
+                    // through as `subcommand`), so existence-check them all.
+                    let stale_cd_path = is_cd_path_context(parsed)
                         && !cd_history_path_exists(&insert_text, &req.cwd);
                     if !stale_cd_path
                         && (insert_text.starts_with(active)
@@ -543,7 +545,7 @@ impl Engine {
                                 display,
                                 kind,
                                 source: "runtime_history".to_string(),
-                                description: Some("Provided by current shell context".to_string()),
+                                description: None,
                             },
                         );
                     }
@@ -557,10 +559,9 @@ impl Engine {
             {
                 let history_candidate = project_history_candidate(&entry.command, parsed);
                 if let Some((insert_text, display, kind)) = history_candidate {
-                    // Drop a cd-path suggestion whose directory no longer exists.
-                    if kind == "path"
-                        && is_cd_path_context(parsed)
-                        && !cd_history_path_exists(&insert_text, &req.cwd)
+                    // Drop a cd-path suggestion whose directory no longer exists
+                    // (any kind — see the runtime-history loop above).
+                    if is_cd_path_context(parsed) && !cd_history_path_exists(&insert_text, &req.cwd)
                     {
                         continue;
                     }
@@ -572,7 +573,7 @@ impl Engine {
                             display,
                             kind,
                             source: "history".to_string(),
-                            description: Some("Previously executed command".to_string()),
+                            description: None,
                         },
                     );
                 }
@@ -608,7 +609,7 @@ impl Engine {
                             &mut candidates,
                             &mut seen,
                             Candidate {
-                                insert_text: doc.item_value.clone(),
+                                insert_text: strip_control_chars(&doc.item_value),
                                 // F8: doc text is user/tool-authored (e.g. a
                                 // --help line) and reaches the terminal raw
                                 // if not sanitized like every other display
@@ -624,13 +625,20 @@ impl Engine {
 
                 if !active.is_empty() {
                     if let Some(query) = sanitize_fts_query(active) {
-                        for doc in self.db.search_docs(&query, self.config.max_results)? {
+                        for doc in self
+                            .db
+                            .search_docs(command, &query, self.config.max_results)?
+                        {
                             if should_include_doc(&doc, active, parsed) {
                                 push_candidate(
                                     &mut candidates,
                                     &mut seen,
                                     Candidate {
-                                        insert_text: doc.item_value.clone(),
+                                        // Strip control bytes (roff overstrike
+                                        // `x\bx` from man pages) so accepting a
+                                        // doc row never injects them into the
+                                        // buffer.
+                                        insert_text: strip_control_chars(&doc.item_value),
                                         // F8: same rationale as the
                                         // docs_for_command branch above.
                                         display: sanitize_display(&doc.item_value),
@@ -662,12 +670,18 @@ impl Engine {
             candidates.retain(|c| c.source != "history" && c.source != "runtime_history");
         }
 
-        if let Some(prev_command) = req
-            .history_hint
-            .prev_command
-            .clone()
-            .or_else(|| self.db.latest_command().ok().flatten())
-        {
+        // Transitions predict the NEXT command, so they only make sense at
+        // command position. Offering "what you run after cd" as a `git`
+        // argument (or a once-pasted sentence as a path) is pure noise.
+        let prev_command = if matches!(parsed.role, TokenRole::Command) {
+            req.history_hint
+                .prev_command
+                .clone()
+                .or_else(|| self.db.latest_command().ok().flatten())
+        } else {
+            None
+        };
+        if let Some(prev_command) = prev_command {
             for transition in self
                 .db
                 .transitions_from(&prev_command, self.config.max_results)?
@@ -675,8 +689,10 @@ impl Engine {
                 if let Some((insert_text, display, kind)) =
                     project_history_candidate(&transition.next, parsed)
                 {
-                    let stale_cd_path = kind == "path"
-                        && is_cd_path_context(parsed)
+                    // In a cd context EVERY argument is a directory, whatever
+                    // `kind` the source assigned (single-segment tokens come
+                    // through as `subcommand`), so existence-check them all.
+                    let stale_cd_path = is_cd_path_context(parsed)
                         && !cd_history_path_exists(&insert_text, &req.cwd);
                     if !stale_cd_path
                         && (insert_text.starts_with(active)
@@ -691,9 +707,7 @@ impl Engine {
                                 display,
                                 kind,
                                 source: "transition".to_string(),
-                                description: Some(format!(
-                                    "Frequently used after `{prev_command}`"
-                                )),
+                                description: None,
                             },
                         );
                     }
@@ -710,7 +724,7 @@ impl Engine {
                                 "history".to_string()
                             },
                             source: "transition".to_string(),
-                            description: Some(format!("Frequently used after `{prev_command}`")),
+                            description: None,
                         },
                     );
                 }
@@ -889,19 +903,37 @@ impl Engine {
         };
 
         let limit = self.config.max_results.saturating_mul(2).max(8);
+        // Local branch names, so a remote-tracking `origin/foo` twin can be
+        // collapsed when the local `foo` already exists (offering both halves
+        // the useful window).
+        let local_names: HashSet<&str> = refs
+            .iter()
+            .filter(|r| !r.starts_with("origin/"))
+            .map(|r| r.as_str())
+            .collect();
         let mut emitted = 0usize;
-        for refname in refs {
+        for refname in &refs {
             if emitted >= limit {
                 break;
+            }
+            // A bare remote name (`origin`) is not a branch.
+            if refname == "origin" {
+                continue;
+            }
+            // Collapse the remote-tracking twin of an existing local branch.
+            if let Some(local) = refname.strip_prefix("origin/") {
+                if local_names.contains(local) {
+                    continue;
+                }
             }
             // Filter: prefix or fuzzy match. Empty `active` keeps everything.
             if !active.is_empty()
                 && !refname.starts_with(active)
-                && fuzzy_match_score(active, &refname) <= 0.0
+                && fuzzy_match_score(active, refname) <= 0.0
             {
                 continue;
             }
-            let display = sanitize_display(&refname);
+            let display = sanitize_display(refname);
             let description = if refname.starts_with("origin/") {
                 Some("remote-tracking branch".to_string())
             } else {
@@ -911,7 +943,7 @@ impl Engine {
                 candidates,
                 seen,
                 Candidate {
-                    insert_text: refname,
+                    insert_text: refname.clone(),
                     display,
                     kind: "branch".to_string(),
                     source: "git_branch".to_string(),
@@ -1445,9 +1477,13 @@ impl Engine {
         // uses, and only carry the top `limit` of those into the expensive
         // SQL-backed scoring pass below.
         let limit = self.config.max_results.saturating_mul(2).max(8);
+        // Case-insensitive prefix match: on a default case-insensitive macOS
+        // filesystem `cd d` should surface Documents/Desktop/Downloads, matching
+        // the shell's own matcher rather than hiding them behind case.
+        let prefix_lc = prefix.to_ascii_lowercase();
         let mut matches: Vec<(String, f64)> = Vec::new();
         for entry in entries {
-            if !entry.starts_with(&prefix) {
+            if !entry.to_ascii_lowercase().starts_with(&prefix_lc) {
                 continue;
             }
             let entry_path = dir.join(&entry);
@@ -1769,26 +1805,45 @@ fn is_cd_path_context(parsed: &ParsedContext) -> bool {
         || matches!(parsed.prev_token.as_deref(), Some("cd"))
 }
 
-/// True if a cd-path candidate resurrected from history still resolves to an
-/// existing directory. Relative tokens resolve against `cwd`; `~/` expands via
-/// `$HOME`. Used to drop stale suggestions like `cd dev/sh-autocomplete/` after
-/// the folder was deleted. An unresolvable `~` (no `$HOME`) is treated as
-/// existing so we never over-filter a path we cannot check.
+/// True if a cd-path candidate resurrected from history plausibly points at a
+/// still-existing directory. Used to drop stale suggestions like
+/// `cd dev/sh-autocomplete/` after the folder was deleted.
+///
+/// The guiding rule is *never over-filter what we cannot cheaply and safely
+/// check* — so anything we can't resolve without the shell (env vars, `~user`,
+/// globs) or that could block on a slow/dead network mount (an absolute path
+/// outside `$HOME`) is kept. Only relative paths (resolved against `cwd`),
+/// `~/…`, and absolute paths under `$HOME` are stat'd, and with `is_dir` (a cd
+/// target that became a regular file is also useless).
 fn cd_history_path_exists(token: &str, cwd: &str) -> bool {
-    if token == "~" {
+    // Unresolvable without the shell — keep.
+    if token == "~"
+        || token.starts_with('$')
+        || token.contains('*')
+        || token.contains('?')
+        || (token.starts_with('~') && !token.starts_with("~/"))
+    {
         return true;
     }
+    let home = std::env::var_os("HOME").map(PathBuf::from);
     let path = if let Some(rest) = token.strip_prefix("~/") {
-        match std::env::var_os("HOME") {
-            Some(home) => PathBuf::from(home).join(rest),
+        match &home {
+            Some(h) => h.join(rest),
             None => return true,
         }
     } else if Path::new(token).is_absolute() {
-        PathBuf::from(token)
+        let p = PathBuf::from(token);
+        // Only stat absolute paths under $HOME (cheap, local). An absolute path
+        // elsewhere may be a slow or dead network mount — never block the daemon
+        // on that stat; keep the candidate.
+        match &home {
+            Some(h) if p.starts_with(h) => p,
+            _ => return true,
+        }
     } else {
         Path::new(cwd).join(token)
     };
-    path.exists()
+    path.is_dir()
 }
 
 fn source_prior(source: &str, kind: &str) -> f64 {
@@ -2609,6 +2664,15 @@ fn sanitize_display(s: &str) -> String {
         }
     }
     out
+}
+
+/// Strip control bytes from a value destined for `insert_text`. Unlike
+/// `sanitize_display` (which is for on-screen text and replaces whitespace with
+/// spaces), this keeps the token insertable — it only removes C0/DEL bytes such
+/// as the backspace in roff overstrike (`x\bx`), which would otherwise land in
+/// the user's command buffer on accept.
+fn strip_control_chars(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
 }
 
 fn sanitize_fts_query(query: &str) -> Option<String> {
@@ -3444,6 +3508,7 @@ mod tests {
     fn cd_history_path_exists_filters_deleted_dirs() {
         let base = unique_tmp("cd-exists");
         fs::create_dir_all(base.join("real")).unwrap();
+        fs::write(base.join("afile"), b"x").unwrap();
         let cwd = base.to_string_lossy().to_string();
 
         // Existing relative dir (with and without trailing slash) is kept.
@@ -3452,14 +3517,25 @@ mod tests {
         // A deleted / never-existed relative dir is filtered out.
         assert!(!cd_history_path_exists("gone/", &cwd));
         assert!(!cd_history_path_exists("real/nope/", &cwd));
-        // Absolute existing / missing.
-        assert!(cd_history_path_exists(
-            base.join("real").to_str().unwrap(),
-            &cwd
-        ));
-        assert!(!cd_history_path_exists("/definitely/not/here/xyzzy", &cwd));
-        // Bare `~` is treated as existing (never over-filter home).
+        // A relative path that resolves to a FILE (not a dir) is filtered — cd
+        // would fail on it too (is_dir, not exists).
+        assert!(!cd_history_path_exists("afile", &cwd));
+
+        // Absolute paths OUTSIDE $HOME are kept unconditionally — never block the
+        // daemon on a stat that could hit a dead network mount, even if missing.
+        assert!(cd_history_path_exists("/definitely/not/here/xyzzy", &cwd));
+
+        // Unresolvable-without-the-shell tokens are kept (never over-filter).
         assert!(cd_history_path_exists("~", &cwd));
+        assert!(cd_history_path_exists("$PROJECTS/api", &cwd));
+        assert!(cd_history_path_exists("~alice/dev", &cwd));
+        assert!(cd_history_path_exists("build/*/out", &cwd));
+
+        // A missing path UNDER $HOME is safe to stat and is filtered.
+        if let Some(home) = std::env::var_os("HOME") {
+            let missing = PathBuf::from(&home).join("shac-cd-exists-nope-xyzzy");
+            assert!(!cd_history_path_exists(missing.to_str().unwrap(), &cwd));
+        }
 
         let _ = fs::remove_dir_all(&base);
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -212,11 +212,11 @@ fn upsert_docs_with_help_shellout(db: &AppDb, command: &str) -> Result<()> {
     Ok(())
 }
 
-/// Split a help/man flags column ("-h, --help", "-m, --message <MSG>",
-/// "--color=<WHEN>") into its individual flag tokens ("-h", "--help"). Stops at
-/// the first metavar so a value placeholder never leaks into an inserted flag,
-/// and drops any attached "=VALUE". Each flag becomes its own candidate so a
-/// user typing either the short or the long form gets a prefix match.
+/// Split a help/man flags column into its individual flag tokens. Handles the
+/// common shapes: `-h, --help`, `-m, --message <MSG>`, `--color=<WHEN>`,
+/// `--color[=WHEN]`, `-i[SUFFIX]`, and metavars interleaved between flags
+/// (`-o FILE, --output FILE`). Each flag becomes its own candidate so a user
+/// typing either the short or the long form gets a prefix match.
 fn flag_tokens(column: &str) -> Vec<String> {
     let mut flags = Vec::new();
     for token in column
@@ -224,27 +224,31 @@ fn flag_tokens(column: &str) -> Vec<String> {
         .map(str::trim)
         .filter(|t| !t.is_empty())
     {
-        if token.starts_with('-') && token.len() > 1 {
-            let flag = token.split('=').next().unwrap_or(token);
+        // A metavar (FILE, <MSG>, WHEN) between or after flags is skipped, not a
+        // terminator — otherwise `-o FILE, --output FILE` would drop `--output`.
+        if !token.starts_with('-') || token.len() <= 1 {
+            continue;
+        }
+        // Strip an attached value/metavar: `--color=<WHEN>`, `--color[=WHEN]`,
+        // `-i[SUFFIX]` -> `--color` / `-i`.
+        let flag = token.split(['=', '[']).next().unwrap_or(token).trim();
+        if flag.starts_with('-') && flag.len() > 1 {
             flags.push(flag.to_string());
-        } else {
-            // A metavar (<MSG>, WHEN, ...) — the flag tokens are done.
-            break;
         }
     }
     flags
 }
 
 /// A help line's first column names a subcommand only when it is a single
-/// lowercase token (letters, digits, hyphens). This rejects prose, `Usage:`
-/// lines, section headers and wrapped descriptions that are not real
-/// subcommands.
+/// lowercase token (letters, digits, hyphens, underscores — e.g. openssl's
+/// `s_client`). This rejects prose, `Usage:` lines, section headers and wrapped
+/// descriptions that are not real subcommands.
 fn is_subcommand_name(token: &str) -> bool {
     token.len() >= 2
         && token.starts_with(|c: char| c.is_ascii_lowercase())
         && token
             .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
 }
 
 fn parse_help_output(command: &str) -> Option<Vec<StoredDoc>> {
@@ -279,12 +283,17 @@ fn parse_help_text(command: &str, stdout: &str) -> Vec<StoredDoc> {
                     return docs;
                 }
             }
-        } else if indented && is_subcommand_name(head) {
+        } else if indented {
             // Subcommand row under a group header ("  install   Add ...").
             // clap groups subcommands under custom headers (Setup:, Index:, ...)
             // rather than a single "Commands:" section, so key off the row
-            // shape, not the header name.
-            docs.push(doc(command, "subcommand", head, description, "help"));
+            // shape, not the header name. Take the primary name (first token) so
+            // aliased rows like cargo's "build, b   Compile ..." index as `build`.
+            let name = head.split([',', ' ', '\t']).next().unwrap_or(head);
+            if !is_subcommand_name(name) {
+                continue;
+            }
+            docs.push(doc(command, "subcommand", name, description, "help"));
             if docs.len() >= MAX_DOCS_PER_COMMAND {
                 return docs;
             }
@@ -382,7 +391,7 @@ fn parse_man_sections(text: &str, command: &str) -> Option<Vec<StoredDoc>> {
     ];
     let mut docs = Vec::new();
     let mut in_section = false;
-    for line in text.lines() {
+    'lines: for line in text.lines() {
         if !line.starts_with(' ') && !line.starts_with('\t') && !line.is_empty() {
             let upper = line.trim().to_uppercase();
             in_section = SECTION_HEADERS.iter().any(|&h| upper.starts_with(h));
@@ -399,8 +408,10 @@ fn parse_man_sections(text: &str, command: &str) -> Option<Vec<StoredDoc>> {
                 if !description.is_empty() {
                     for flag in flag_tokens(column) {
                         docs.push(doc(command, "option", &flag, description, "man"));
+                        // Break the LINE loop (not just the flag loop) so the cap
+                        // actually bounds total docs.
                         if docs.len() >= MAX_DOCS_PER_COMMAND {
-                            break;
+                            break 'lines;
                         }
                     }
                 }
@@ -674,10 +685,18 @@ mod tests {
     fn flag_tokens_extracts_individual_flags_without_metavars() {
         assert_eq!(flag_tokens("-h, --help"), vec!["-h", "--help"]);
         assert_eq!(flag_tokens("-V, --version"), vec!["-V", "--version"]);
-        // Metavar terminates the flag list; never leaks into an inserted flag.
+        // Trailing metavar never leaks into an inserted flag.
         assert_eq!(flag_tokens("-m, --message <MSG>"), vec!["-m", "--message"]);
-        // Attached =VALUE is stripped.
+        // A metavar BETWEEN flags (old argparse) is skipped, not a terminator:
+        // the long form must survive.
+        assert_eq!(
+            flag_tokens("-o FILE, --output FILE"),
+            vec!["-o", "--output"]
+        );
+        // Attached =VALUE and bracketed optional values are stripped.
         assert_eq!(flag_tokens("--color=<WHEN>"), vec!["--color"]);
+        assert_eq!(flag_tokens("--color[=WHEN]"), vec!["--color"]);
+        assert_eq!(flag_tokens("-i[SUFFIX]"), vec!["-i"]);
         assert_eq!(flag_tokens("--long-only"), vec!["--long-only"]);
     }
 
@@ -709,6 +728,7 @@ Setup:
 Diagnostics:
   doctor                 Check that the daemon is healthy
   reset-personalization  Clear all learned preferences
+  build, b               Aliased row (cargo-style): index the primary name
 
 Options:
   -h, --help     Print help
@@ -727,6 +747,9 @@ Run 'shac help <COMMAND>' for more information on a specific command.
         assert!(subs.contains(&"daemon"));
         assert!(subs.contains(&"doctor"));
         assert!(subs.contains(&"reset-personalization"));
+        // Aliased row indexes the primary name, not the comma-joined column.
+        assert!(subs.contains(&"build"), "cargo-style alias: {subs:?}");
+        assert!(!subs.iter().any(|s| s.contains(',')));
 
         let opts: Vec<&str> = docs
             .iter()


### PR DESCRIPTION
Batch of fixes from a three-lens Fable review (engine correctness, release pipeline, completion usability). Scope chosen by the user: **Tier 1 (correctness) + Tier 2 (usability wins)**; the ranking-philosophy Tier-3 items are a separate decision.

## Tier 1 — correctness
- **Full command line accept** — a history row like `cd ..` was inserted token-escaped (`cd\ ..`) and executed as one broken word (`command not found: cd ..`), then re-learned. Multi-word `history`/`command` candidates now insert **raw**; single tokens (paths/options) stay escaped.
- **cd existence filter, kind hole + hardening** — the v0.6.8 filter only ran for `kind=="path"`, but single-segment history tokens arrive as `subcommand`, so `cd d<Tab>` still offered a deleted `dev/sh-autocomplete/`. Now every cd-argument candidate is existence-checked, and the check keeps `$VAR`/`~user`/glob tokens and absolute paths outside `$HOME` (never block the daemon on a dead network mount), using `is_dir`.
- **`flag_tokens`** — a metavar between flags no longer drops the long form (`-o FILE, --output FILE` → both); `--color[=WHEN]`/`-i[SUFFIX]` brackets stripped. The man-page doc cap works again (a mis-scoped `break` had disabled it).
- **`doc_search` scoped to the current command** — `git c<Tab>` no longer leaks mdfind's `-case_sensitive` etc.; doc `insert_text` is stripped of control bytes (roff overstrike) so accept never injects them.
- **Release pipeline can't ship an empty sha** — fetch failure now fails the step (plain assignment, not `echo "$(...)"`); the tap renderer rejects any sha256 that isn't 64 hex chars.
- **Doctor version probe** — read-only (`SHAC_NO_TIPS`, no first-run-greeter burn); a daemon answering without a version field is now a confirmed pre-0.5.2 skew (fail, not pass).

## Tier 2 — usability
- **Transitions only at command position** — no more `git c<Tab>` → `clr`, or a once-pasted sentence as an argument.
- **Subcommand indexing** reads aliased rows (cargo `build, b` → `build`) and `_` names.
- **Branch completion** collapses `origin/foo` twins of local `foo`, drops bare `origin`.
- **Case-insensitive path prefix** (macOS `cd d` → `Documents/`).
- Dropped boilerplate per-row descriptions.

## Validation
fmt + clippy + full suite (348 tests, new tests for flag_tokens/cargo-alias/cd-hardening/version-skew) + **E2E on a release daemon**: raw full-line insert, deleted dir filtered at kind=subcommand, doc_search command-scoped, transitions gated, empty-sha rejected by the renderer.

## Deferred (honest scope cut — follow-up candidates)
- Trailing-slash path dupes (`dev` vs `dev/` as two rows).
- `count>=2` demotion of one-off typo'd history (`clr --resu,e`) — needs history-frequency thresholding.
- A dedicated unit test for the v0.6.8 command cap (currently E2E-verified only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)