### PR TITLE
fix: wire-seam hardening — status leak erased typed token (v0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.6.11 — 2026-07-11
+
+Wire-protocol hardening from the holistic Fable review (the seam three focused
+reviews each assumed the other owned).
+
+### Fixed
+- **A daemon-start status line no longer erases your typed token (F1).** When the
+  daemon was down (first shell after boot, after a crash, or `shac daemon stop`),
+  `complete` auto-started it and printed `started`/`running` to **stdout — the
+  same stream the widgets parse as completion rows** — so `cd sr<Tab>` opened a
+  menu whose blank first row was applied, deleting the `sr`. The auto-start path
+  is now silent (`ensure_daemon` never prints); interactive `shac daemon start`
+  still reports status. All three adapters additionally ignore any tab-less line
+  as a non-candidate (defense in depth).
+- **Empty `request_id` field no longer shifts wire parsing (F2).** A
+  zero-candidate response emitted an empty field; zsh's `${(ps:\t:)}` elides
+  empty elements and bash's `IFS=$'\t' read -a` collapses consecutive tabs, so
+  both misread the following field — in bash that produced a non-numeric
+  `--accepted-request-id` and **silently dropped the recorded command**. The id
+  now defaults to `0` (a non-empty, non-matching sentinel).
+
 ## v0.6.10 — 2026-07-11
 
 Fixes from a three-lens Fable review (engine, release pipeline, usability).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/shell/bash/shac.bash
+++ b/shell/bash/shac.bash
@@ -135,6 +135,9 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
         # show a tip in, and they must not be mistaken for a candidate row.
         continue
       else
+        # A candidate row always has tab-separated fields; a tab-less line (a
+        # stray daemon status message on stdout) is not a candidate (F1).
+        [[ "$resp_line" != *$'\t'* ]] && continue
         local -a fields
         IFS=$'\t' read -r -a fields <<< "$resp_line"
         _shac_decode "${fields[1]:-}"

--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -710,6 +710,11 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
         # __shac_* lines without this adapter mis-rendering them.
         continue
       else
+        # A candidate row always has tab-separated fields; a tab-less line
+        # (e.g. a stray daemon status message that leaked onto stdout) is not a
+        # candidate and must never be rendered as a phantom row that erases the
+        # typed token (F1).
+        [[ "$line" != *$'\t'* ]] && continue
         local -a fields
         fields=("${(ps:\t:)line}")
         _shac_decode "${fields[1]:-}"

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -1621,35 +1621,46 @@ fn rc_file_for_shell(shell: ShellKind) -> Result<PathBuf> {
     })
 }
 
+/// Start the daemon if it is not already running, printing NOTHING. Safe to
+/// call from the completion path, whose stdout is a protocol stream the shell
+/// widgets parse — a stray "started"/"running" line there becomes a phantom
+/// completion candidate that erases the user's typed token (F1). Returns true
+/// if the daemon was already up, false if it was freshly started.
+fn start_daemon_quiet(paths: &AppPaths) -> Result<bool> {
+    cleanup_stale_daemon_state(paths);
+    if daemon_is_running(paths) {
+        return Ok(true);
+    }
+    let daemon_bin = daemon_binary_path()?;
+    let command = format!(
+        "if command -v setsid >/dev/null 2>&1; then nohup setsid {} >/dev/null 2>&1 </dev/null & else nohup {} >/dev/null 2>&1 </dev/null & fi",
+        shell_escape(&daemon_bin.to_string_lossy()),
+        shell_escape(&daemon_bin.to_string_lossy())
+    );
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .status()
+        .context("start shacd with detached shell")?;
+    if !status.success() {
+        bail!("failed to launch daemon process");
+    }
+    if wait_for_socket(&paths.socket_file, Duration::from_secs(2)) {
+        Ok(false)
+    } else {
+        bail!("daemon did not create socket in time")
+    }
+}
+
 fn daemon_action(paths: &AppPaths, action: DaemonAction) -> Result<()> {
     match action {
         DaemonAction::Start => {
-            cleanup_stale_daemon_state(paths);
-            if daemon_is_running(paths) {
+            if start_daemon_quiet(paths)? {
                 println!("running");
-                return Ok(());
-            }
-            let daemon_bin = daemon_binary_path()?;
-            let command = format!(
-                "if command -v setsid >/dev/null 2>&1; then nohup setsid {} >/dev/null 2>&1 </dev/null & else nohup {} >/dev/null 2>&1 </dev/null & fi",
-                shell_escape(&daemon_bin.to_string_lossy()),
-                shell_escape(&daemon_bin.to_string_lossy())
-            );
-            let status = Command::new("sh")
-                .arg("-c")
-                .arg(command)
-                .status()
-                .context("start shacd with detached shell")?;
-            if !status.success() {
-                bail!("failed to launch daemon process");
-            }
-            let started = wait_for_socket(&paths.socket_file, Duration::from_secs(2));
-            if started {
-                println!("started");
-                Ok(())
             } else {
-                bail!("daemon did not create socket in time")
+                println!("started");
             }
+            Ok(())
         }
         DaemonAction::Stop => {
             if !paths.pid_file.exists() {
@@ -1847,11 +1858,16 @@ fn print_completion_response(
     if format == "json" {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else if format == "shell-tsv-v3" {
+        // Never emit an empty field: zsh's `${(ps:\t:)}` elides empty elements
+        // and bash's `IFS=$'\t' read -a` collapses consecutive tabs, so an empty
+        // request_id would shift every following field (F2) — in bash that fed a
+        // non-numeric `--accepted-request-id` and silently dropped the recorded
+        // command. `0` is a safe non-id sentinel (real ids are positive).
         let request_id = response
             .get("request_id")
             .and_then(|value| value.as_i64())
             .map(|value| value.to_string())
-            .unwrap_or_default();
+            .unwrap_or_else(|| "0".to_string());
         let mode = response
             .get("mode")
             .and_then(|value| value.as_str())
@@ -2085,11 +2101,10 @@ fn reset_personalization(paths: &AppPaths) -> Result<()> {
 }
 
 fn ensure_daemon(paths: &AppPaths) -> Result<()> {
-    cleanup_stale_daemon_state(paths);
-    if daemon_is_running(paths) {
-        return Ok(());
-    }
-    daemon_action(paths, DaemonAction::Start)
+    // Quiet start: this runs inside `complete`, whose stdout is the protocol
+    // stream (F1). Never print a status line here.
+    start_daemon_quiet(paths)?;
+    Ok(())
 }
 
 fn shac_disabled(paths: &AppPaths) -> Result<bool> {


### PR DESCRIPTION
The first two findings from the **holistic (unfocused) Fable review** — a seam the three focused reviews each assumed the other owned.

## F1 — CRITICAL — a daemon-start status line erased the typed token
Daemon down (first shell after boot, after a crash, or `shac daemon stop`) → `complete` auto-started it via `ensure_daemon` → `daemon_action(Start)` → `println!("started")` to **stdout**, the stream the widgets parse as completion rows. `cd sr<Tab>` opened a menu whose blank first row was applied → the typed `sr` was deleted (worse: if the first request also timed out, `started` was the only line → `total==1` path applied it with no menu). Present since the initial beta.

**Fix:** `ensure_daemon` uses a new silent `start_daemon_quiet`; interactive `shac daemon start` still prints status. All three adapters also skip any tab-less line as a non-candidate (defense in depth; fish already validated arity).

## F2 — HIGH — empty `request_id` field shifted wire parsing (bash dropped recorded commands)
A zero-candidate response emitted an empty field. zsh's `${(ps:\t:)}` elides empty split elements and bash's `IFS=$'\t' read -a` collapses consecutive tabs → both misread the next field. In bash that fed a non-numeric `--accepted-request-id`, clap rejected it (exit 2), and the command was **silently not recorded**. `request_id` now defaults to `0`.

## Validation
fmt + clippy + full suite (348) + `zsh -n`/`bash -n` + E2E: a daemon-down `complete` no longer leaks a status line onto stdout (first line is `__shac_request_id`).

## Remaining holistic findings (F3–F8, F10)
Being handled next; a couple need a product steer (history retention policy; whether to make "full line" an explicit protocol flag). Tracked separately so this live-CRITICAL fix ships without delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)