### PR TITLE
v0.6.12: security, resource safety, history retention + widget/daemon seam (F3–F8, F10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## v0.6.12 — 2026-07-11
+
+The rest of the holistic Fable review, batched: security, resource safety, a
+privacy-respecting history model, and the widget/daemon seam unified behind one
+protocol flag.
+
+### Security & resource safety
+- **State is now owner-only (F5).** The config/data/state dirs are chmod'd
+  `0700`, the history DB `0600`, and the **unauthenticated control socket**
+  `0600` right after bind — previously any local user could `complete`, read
+  `stats`, or poison learning over it. `SHAC_LOCALE` is sanitized before it
+  reaches a path join (no traversal to an arbitrary `.toml`), and the per-locale
+  catalog cache is bounded so a client can't grow daemon memory by spamming
+  distinct locales.
+- **Daemon shellouts can no longer deadlock or truncate (F10).** Every
+  `git`/`kubectl`/`docker`/`--help`/`man` call went "poll for exit, then read
+  stdout" — which deadlocks whenever the child writes more than one pipe buffer
+  (~64 KiB) before exiting, as `man` and large `--help` routinely do: the child
+  blocks on `write()`, the timeout fires, and the output is lost. All six sites
+  now drain stdout on a reader thread concurrently with the timed wait. As a
+  side effect `--help` is now reliably the primary doc source (it had been
+  masked by `man` silently deadlocking), matching the documented intent.
+
+### Privacy & history
+- **Command history retention is configurable (F4).** The daemon prunes
+  `history_events` older than `history_retention_days` (default 365) on its
+  background tick, so the DB stays bounded over months of use. `0` keeps no
+  persistent history.
+- **Two commands are never recorded:** anything typed with a **leading space**
+  (the `HISTCONTROL=ignorespace` / `HIST_IGNORE_SPACE` convention — so a one-off
+  ` export TOKEN=…` or ` cd /private` leaves no trace in history, transitions, or
+  the cd index), and everything while shac is disabled. Inline `cd`-frecency
+  learning is gated on the same clean-interactive signal as transitions, so
+  pasted/imported `cd`s no longer seed path-jump suggestions.
+
+### Fixed — completion correctness
+- **The widget and daemon agree on whole-line completions (F3/F7/F8).** Whether a
+  candidate is a full command line (resurrected from history, replaces the whole
+  buffer, runs on Enter) is now decided once by the daemon and shipped as a
+  `full_line` flag, instead of the CLI keying off `kind` and each widget keying
+  off `source` — two approximations that drifted and could escape a line
+  per-token while treating it as runnable. zsh keys Enter/insert off the flag;
+  bash and fish need no change.
+- **Redirect targets complete as files, not commands (F3).** `cat > fi<Tab>` now
+  offers filenames — the token after `>`/`<`/`>>` is classified as a path.
+- **bash's active-token span is quote-aware (F6).** `cat "my fi<Tab>` completes
+  the whole `"my fi` span instead of just the trailing `fi` and mangling the
+  quote, matching the zsh widget.
+- **`shac reindex` no longer reports a false failure on a large PATH.** The
+  client capped the wait at 1.5 s, so a reindex that legitimately took longer
+  (big PATH, slow CI) surfaced a "read daemon response" error while the daemon
+  was still finishing. The ceiling for this explicit, non-latency-sensitive
+  command is now 30 s.
+
 ## v0.6.11 — 2026-07-11
 
 Wire-protocol hardening from the holistic Fable review (the seam three focused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,45 @@ protocol flag.
   `bind -x` path returned without deferring to readline (which a `bind -x`
   handler can't invoke), so a down/disabled daemon left Tab inert. It now
   emulates default filesystem completion for simple tokens (unique match or
-  longest common prefix), leaving quoted/escaped/`~` tokens untouched.
+  longest common prefix), leaving quoted/escaped/`~` tokens untouched; at the
+  command position it completes command names, not filenames.
+
+### Fixed — from an adversarial (Fable) review of this batch
+- **Configuring history retention no longer wipes your imported history.**
+  Plain (non-`EXTENDED_HISTORY`) zsh history imports as `ts = 0` with the real
+  clock in `imported_at`; the new prune keyed only on `ts`, so the first
+  background tick deleted the entire imported corpus (and re-armed on
+  re-import). Retention now keys off whichever of `ts`/`imported_at` is more
+  recent.
+- **The whole-line Enter feature actually works in zsh now.** The candidate
+  TSV split elided the empty description field, shifting the `full_line` flag
+  into the description slot — so Enter on a resurrected history line inserted
+  instead of running it, and a stray `1`/`0` showed as the menu description.
+- **A daemon shellout can no longer wedge completions.** A grandchild that
+  inherited a `git`/`man`/`--help` process's stdout pipe kept the drain from
+  seeing EOF, blocking the single-threaded daemon far past the timeout. Each
+  shellout now runs in its own process group (killed as a unit on timeout) and
+  the collect is bounded, so a stuck descendant can't stall other shells.
+- **Resurrecting a history line after `&&`/`|`/`;` no longer breaks it.** The
+  escape decision was tied to the Enter-runs-it flag, but a whole history line
+  offered at a chained command position isn't a whole-buffer replacement, so it
+  was per-token escaped into `git\ commit\ …`. Escaping now keys off a separate
+  "already valid shell" signal.
+- **`config set enabled false` now stops a running daemon from recording.** The
+  daemon cached `enabled` at startup and the client never re-checked it, so
+  recording continued after a disable while completions went quiet. The client
+  now honors the kill-switch and the daemon reloads `enabled` per record.
+- **Redirect targets complete files again.** `cat > <Tab>` / `cat > -n<Tab>`
+  returned nothing (the path dispatch was gated on a command the redirect
+  segment doesn't have); they now offer filesystem candidates.
+- **bash multibyte cursor fix.** `mv Café tmp` with the cursor after `Café`
+  selected the wrong token (a byte offset fed a character-indexed walker); the
+  offset is now converted first.
+- Locale cache keys are sanitized (a hostile `SHAC_LOCALE` can no longer bloat
+  the per-locale cache); the control socket's actual mode is checked at startup
+  and warned about if not owner-only. Note: a `--help` that prints then hangs
+  past its deadline now indexes nothing from help (previously a truncated
+  parse), with `man` as the fallback.
 
 ## v0.6.11 — 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,23 @@ protocol flag.
   was still finishing. The ceiling for this explicit, non-latency-sensitive
   command is now 30 s.
 
+### Fixed — follow-ups from prior-PR review comments
+- **A no-match Tab no longer mis-attributes the next command.** v0.6.11's F2
+  fix emitted `0` (instead of an empty field) for a zero-candidate response;
+  clients then treated that non-empty sentinel as a live request id, so running
+  the line within 30 s recorded `--accepted-request-id 0` and the server
+  fell back to guessing a recent request. All three adapters now treat `0` as
+  "no request".
+- **A history flag no longer shadows a `-file` path candidate.** In a path
+  context, a dash-prefixed history token (e.g. `vim -notes`) was classified as
+  an option and could win over the real path candidate, dropping the leading-
+  dash `./` guard; it now stays a path (`./-notes`).
+- **bash Tab is no longer a dead key when shac has no candidate.** The bash≥4
+  `bind -x` path returned without deferring to readline (which a `bind -x`
+  handler can't invoke), so a down/disabled daemon left Tab inert. It now
+  emulates default filesystem completion for simple tokens (unique match or
+  longest common prefix), leaving quoted/escaped/`~` tokens untouched.
+
 ## v0.6.11 — 2026-07-11
 
 Wire-protocol hardening from the holistic Fable review (the seam three focused

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "blake3",
  "clap",
  "dirs",
+ "libc",
  "regex",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 blake3 = "1"
 toml = "1.1"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -317,8 +317,14 @@ you still benefit from.
 
 ```bash
 shac config set history_retention_days 90   # keep three months
-shac config set history_retention_days 0    # no persistent history at all
+shac config set history_retention_days 0    # prune history_events every tick
 ```
+
+Retention prunes the `history_events` table. Aggregates derived from it —
+learned `transitions` and the `cd` frecency index (`paths_index`) — are not
+time-stamped and are **not** cleared by retention, so `0` bounds the raw log
+but is not a privacy wipe. To erase all learned personalization, run
+`shac reset-personalization`.
 
 Two commands are never recorded in the first place:
 

--- a/README.md
+++ b/README.md
@@ -328,10 +328,12 @@ but is not a privacy wipe. To erase all learned personalization, run
 
 Two commands are never recorded in the first place:
 
-- Anything typed with a **leading space** (the same `HISTCONTROL=ignorespace` /
-  `HIST_IGNORE_SPACE` convention your shell uses) — so a one-off
-  ` export TOKEN=…` or ` cd /private` leaves no trace in history, transitions,
-  or the `cd` frecency index.
+- Anything typed with a **leading space** — so a one-off ` export TOKEN=…` or
+  ` cd /private` leaves no trace in history, transitions, or the `cd` frecency
+  index. On zsh/fish this is enforced by shac directly (the record hook sees
+  the raw line). On bash, shac records via `history`, which drops the leading
+  space, so this relies on bash's own `HISTCONTROL=ignorespace` (which then
+  never stores the command for shac to see) — set it if you want the marker.
 - Everything, while shac is disabled (`shac config set enabled false`).
 
 ## Trust-aware migration

--- a/README.md
+++ b/README.md
@@ -307,6 +307,27 @@ shac config set telemetry_retention_days 0    # max privacy: prune everything on
 A running daemon picks up the new value on its next prune tick — no restart
 needed.
 
+### Command-history retention
+
+Recorded shell commands (`history_events`) are the corpus behind history-based
+completion and learned command transitions. The daemon prunes rows older than
+`history_retention_days` (default 365) on the same tick as telemetry, so the
+database stays bounded over months of use without throwing away suggestions
+you still benefit from.
+
+```bash
+shac config set history_retention_days 90   # keep three months
+shac config set history_retention_days 0    # no persistent history at all
+```
+
+Two commands are never recorded in the first place:
+
+- Anything typed with a **leading space** (the same `HISTCONTROL=ignorespace` /
+  `HIST_IGNORE_SPACE` convention your shell uses) — so a one-off
+  ` export TOKEN=…` or ` cd /private` leaves no trace in history, transitions,
+  or the `cd` frecency index.
+- Everything, while shac is disabled (`shac config set enabled false`).
+
 ## Trust-aware migration
 
 When this version starts on an existing database, old personalization data is kept and marked as `legacy`.

--- a/shell/bash/shac.bash
+++ b/shell/bash/shac.bash
@@ -77,20 +77,41 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
   }
 
   _shac_bash_active_region() {
-    # Whitespace-delimited word spanning the cursor: everything before it
-    # goes in _shac_bash_before, everything from the next whitespace onward
-    # goes in _shac_bash_after, so an accept replaces the whole active token
-    # (not just the part left of the cursor). Naive/not quote-aware -- same
-    # heuristic the zsh widget uses; context::parse's quote-awareness governs
-    # what insert_text itself looks like, not where widgets splice it in.
+    # Word spanning the cursor, honoring shell quoting: whitespace inside a
+    # quoted (`"`/`'`) or backslash-escaped region does NOT split the token, so
+    # `cat "my fi<Tab>` completes the whole `"my fi` span rather than just the
+    # trailing `fi` and mangling the quote on splice (F6). Everything left of
+    # the token goes in _shac_bash_before, everything from the token's end
+    # onward in _shac_bash_after, so an accept replaces the whole active token.
+    # Mirrors the zsh widget's _shac_active_token_span.
     local base_line="$1" base_point="$2"
-    local left right token_prefix token_suffix
-    left="${base_line:0:base_point}"
-    right="${base_line:base_point}"
-    token_prefix="${left##*[[:space:]]}"
-    _shac_bash_before="${left:0:$(( ${#left} - ${#token_prefix} ))}"
-    token_suffix="${right%%[[:space:]]*}"
-    _shac_bash_after="${right#"$token_suffix"}"
+    local -i len=${#base_line} i=0 start=0 end=${#base_line} escaped=0
+    local quote="" c
+    while (( i < len )); do
+      c="${base_line:i:1}"
+      if (( escaped )); then
+        escaped=0
+      elif [[ "$c" == "\\" ]]; then
+        escaped=1
+      elif [[ "$c" == '"' || "$c" == "'" ]]; then
+        if [[ "$quote" == "$c" ]]; then
+          quote=""
+        elif [[ -z "$quote" ]]; then
+          quote="$c"
+        fi
+      elif [[ -z "$quote" && "$c" == [[:space:]] ]]; then
+        if (( i < base_point )); then
+          # Whitespace left of the cursor: the token starts after it.
+          start=$(( i + 1 ))
+        elif (( end == len )); then
+          # First whitespace at/after the cursor closes the token.
+          end=$i
+        fi
+      fi
+      i+=1
+    done
+    _shac_bash_before="${base_line:0:start}"
+    _shac_bash_after="${base_line:end}"
   }
 
   _shac_bash_byte_length() {

--- a/shell/bash/shac.bash
+++ b/shell/bash/shac.bash
@@ -150,6 +150,12 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
         local -a header
         IFS=$'\t' read -r -a header <<< "$resp_line"
         _shac_decode "${header[1]:-}"
+        # "0" is the daemon's no-traceable-request sentinel (a zero-candidate
+        # response keeps the TSV field non-empty for wire alignment — F2).
+        # Treat it as "no request" so the 30s accept heuristic below never
+        # sends --accepted-request-id 0 for a no-match Tab, which the server
+        # would mis-attribute to an unrelated recent request (codex/#40).
+        [[ "$REPLY" == "0" ]] && REPLY=""
         request_id="$REPLY"
       elif [[ "$resp_line" == __shac_*$'\t'* ]]; then
         # Skip other sentinel rows (e.g. __shac_tip) -- bash has no menu to
@@ -171,6 +177,45 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
       _shac_last_completion_line="$line"
       _shac_last_completion_ts="$(date +%s)"
     fi
+  }
+
+  _shac_bash_default_fallback() {
+    # readline's own Tab is unreachable from a bind -x handler, so when shac
+    # has no candidate (daemon down/disabled/timed out, or no match) Tab would
+    # otherwise be a dead key (codex/#28). Emulate the default filesystem
+    # completion for the active token so Tab keeps working. Scope guard: only
+    # SIMPLE tokens (no quoting/escaping, no `~`) — for those we can't safely
+    # reconstruct the user's intent, so leave them a no-op rather than risk a
+    # wrong splice. Multi-match LISTING is out of scope (a bind -x handler
+    # can't cleanly redraw the completion list); we still insert the longest
+    # common prefix, which is the useful part.
+    local token="$1"
+    case "$token" in
+      *[\'\"\\~]*) return ;;
+    esac
+    local -a matches=()
+    local m
+    while IFS= read -r m; do matches+=("$m"); done < <(compgen -f -- "$token" 2>/dev/null)
+    (( ${#matches[@]} == 0 )) && return
+    local completion="${matches[0]}"
+    if (( ${#matches[@]} == 1 )); then
+      [[ -d "$completion" ]] && completion="${completion%/}/"
+    else
+      # Longest common prefix across all matches.
+      for m in "${matches[@]:1}"; do
+        while [[ "$m" != "$completion"* ]]; do
+          completion="${completion%?}"
+          [[ -z "$completion" ]] && return
+        done
+      done
+    fi
+    # Only act if it actually extends what's typed.
+    [[ "$completion" == "$token" ]] && return
+    local escaped
+    printf -v escaped '%q' "$completion"
+    READLINE_LINE="${_shac_bash_before}${escaped}${_shac_bash_after}"
+    _shac_bash_byte_length "${_shac_bash_before}${escaped}"
+    READLINE_POINT=$REPLY
   }
 
   _shac_bash_complete() {
@@ -195,7 +240,13 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
     cursor_chars="$REPLY"
     _shac_bash_request "$line" "$cursor_chars"
 
-    [[ ${#_shac_bash_candidates[@]} -eq 0 ]] && return
+    if [[ ${#_shac_bash_candidates[@]} -eq 0 ]]; then
+      # The active token is the region between the before/after splice points.
+      local token="${line:${#_shac_bash_before}}"
+      token="${token%"$_shac_bash_after"}"
+      _shac_bash_default_fallback "$token"
+      return
+    fi
     _shac_bash_splice_candidate
   }
 

--- a/shell/bash/shac.bash
+++ b/shell/bash/shac.bash
@@ -176,6 +176,13 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
       _shac_last_request_id="$request_id"
       _shac_last_completion_line="$line"
       _shac_last_completion_ts="$(date +%s)"
+    else
+      # A no-request (zero-candidate, "0" sentinel) response: clear any stale
+      # accept-tracking so a later command can't be attributed to an unrelated
+      # earlier completion, matching the zsh adapter's unconditional reset.
+      _shac_last_request_id=""
+      _shac_last_completion_line=""
+      _shac_last_completion_ts=""
     fi
   }
 
@@ -202,6 +209,10 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
       genflag="-c"
       is_cmd_position=1
     fi
+    # NB: a filename containing a literal newline fractures into two "matches"
+    # here (compgen is newline-delimited), so the common-prefix may splice a
+    # path that doesn't exist — a harmless no-op on the next Tab. Not worth the
+    # complexity of NUL-delimited parsing for so pathological an input.
     local -a matches=()
     local m
     while IFS= read -r m; do matches+=("$m"); done < <(compgen "$genflag" -- "$token" 2>/dev/null)

--- a/shell/bash/shac.bash
+++ b/shell/bash/shac.bash
@@ -193,13 +193,23 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
     case "$token" in
       *[\'\"\\~]*) return ;;
     esac
+    # At the command position (nothing but whitespace before the token) real
+    # readline completes command NAMES, not filenames; elsewhere it completes
+    # files. Match that so a down-daemon `git<Tab>` at the prompt doesn't turn
+    # into a filename prefix (codex/#28 follow-up).
+    local genflag="-f" is_cmd_position=0
+    if [[ "$_shac_bash_before" =~ ^[[:space:]]*$ ]]; then
+      genflag="-c"
+      is_cmd_position=1
+    fi
     local -a matches=()
     local m
-    while IFS= read -r m; do matches+=("$m"); done < <(compgen -f -- "$token" 2>/dev/null)
+    while IFS= read -r m; do matches+=("$m"); done < <(compgen "$genflag" -- "$token" 2>/dev/null)
     (( ${#matches[@]} == 0 )) && return
     local completion="${matches[0]}"
     if (( ${#matches[@]} == 1 )); then
-      [[ -d "$completion" ]] && completion="${completion%/}/"
+      # Trailing slash only makes sense for a uniquely-completed directory.
+      (( is_cmd_position == 0 )) && [[ -d "$completion" ]] && completion="${completion%/}/"
     else
       # Longest common prefix across all matches.
       for m in "${matches[@]:1}"; do
@@ -231,13 +241,18 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
       return
     fi
 
-    _shac_bash_active_region "$line" "$point"
-    _shac_bash_cycle_index=0
-
-    # READLINE_POINT is a byte offset; --cursor wants characters (F9).
+    # READLINE_POINT is a BYTE offset; both the daemon (--cursor) and the
+    # quote-aware region walker index CHARACTERS, so convert once up front and
+    # feed the char offset to both. Passing the raw byte point to
+    # active_region selected the wrong token when multibyte text sat before a
+    # mid-line cursor, e.g. `mv Café tmp` cursor after `Café` grabbed `tmp` (F9).
     local cursor_chars
     _shac_bash_char_point "$line" "$point"
     cursor_chars="$REPLY"
+
+    _shac_bash_active_region "$line" "$cursor_chars"
+    _shac_bash_cycle_index=0
+
     _shac_bash_request "$line" "$cursor_chars"
 
     if [[ ${#_shac_bash_candidates[@]} -eq 0 ]]; then

--- a/shell/fish/shac.fish
+++ b/shell/fish/shac.fish
@@ -81,6 +81,10 @@ else if status is-interactive
           # decoded field would fracture and later expand as multiple
           # positional args instead of the single string it decoded to.
           set request_id (__shac_decode $parts[2] | string collect)
+          # "0" is the daemon's no-traceable-request sentinel (zero-candidate
+          # response, kept non-empty for wire alignment — F2). Treat as none so
+          # a later accept never sends --accepted-request-id 0 (codex/#40).
+          test "$request_id" = "0"; and set request_id ""
         else if string match -q '__shac_*' -- $parts[1]
           # Skip any other sentinel rows (e.g. __shac_tip) — inline accept only
           # consumes a real candidate row, mirrors zsh shac.zsh _shac_fetch_inline.

--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -720,7 +720,14 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
         # typed token (F1).
         [[ "$line" != *$'\t'* ]] && continue
         local -a fields
-        fields=("${(ps:\t:)line}")
+        # The `@` flag preserves interior EMPTY fields. Without it, a candidate
+        # with no description (field 6 — every history/runtime/transition and
+        # path row: `description: None` daemon-side) collapses the double tab,
+        # shifting field 7 (`full_line`) into the description slot: the flag is
+        # lost (defaults to 0 → whole-line Enter is inert) and a stray `1`/`0`
+        # renders as the menu description. Old 6-field rows stay compatible:
+        # the unset field 7 still `:-0`-defaults. (F3/F7/F8 regression fix.)
+        fields=("${(@ps:\t:)line}")
         _shac_decode "${fields[1]:-}"
         _shac_menu_item_keys+=("$REPLY")
         _shac_decode "${fields[2]:-}"

--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -272,6 +272,8 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
       if [[ "$line" == __shac_request_id$'\t'* ]]; then
         local -a header=("${(ps:\t:)line}")
         _shac_decode "${header[2]:-}"
+        # "0" is the no-request sentinel, not a real id (see _shac_open_menu).
+        [[ "$REPLY" == "0" ]] && REPLY=""
         request_id="$REPLY"
       elif [[ "$line" == __shac_*$'\t'* ]]; then
         # Skip any other sentinel rows (e.g. __shac_tip) — inline mode only
@@ -684,6 +686,12 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
         local -a header
         header=("${(ps:\t:)line}")
         _shac_decode "${header[2]:-}"
+        # "0" is the daemon's no-traceable-request sentinel (emitted for a
+        # zero-candidate response so the TSV request-id field stays non-empty
+        # and doesn't shift wire parsing — F2). Treat it as "no request" so a
+        # later accept-record never sends --accepted-request-id 0, which the
+        # server would mis-attribute to an unrelated recent request (codex/#40).
+        [[ "$REPLY" == "0" ]] && REPLY=""
         _shac_last_request_id="$REPLY"
       elif [[ "$line" == __shac_tip$'\t'* ]]; then
         if [[ -z "${SHAC_NO_TIPS:-}" ]]; then

--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -29,6 +29,7 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
   typeset -ga _shac_menu_kinds=()
   typeset -ga _shac_menu_sources=()
   typeset -ga _shac_menu_descriptions=()
+  typeset -ga _shac_menu_full_lines=()
   typeset -g _shac_ui_menu_detail="compact"
   typeset -gi _shac_ui_show_kind=0
   typeset -gi _shac_ui_show_source=0
@@ -77,6 +78,7 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
     _shac_menu_kinds=()
     _shac_menu_sources=()
     _shac_menu_descriptions=()
+    _shac_menu_full_lines=()
     _shac_pending_tip_id=""
     _shac_pending_tip_text=""
   }
@@ -431,14 +433,6 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
     REPLY="${_shac_menu_kinds[$_shac_menu_selected_index]:-}"
   }
 
-  function _shac_selected_source() {
-    REPLY="${_shac_menu_sources[$_shac_menu_selected_index]:-}"
-  }
-
-  function _shac_selected_item_key() {
-    REPLY="${_shac_menu_item_keys[$_shac_menu_selected_index]:-}"
-  }
-
   function _shac_selected_requires_more_input() {
     local kind="$1"
     local insert_text="$2"
@@ -458,9 +452,11 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
   }
 
   function _shac_selected_is_full_line() {
-    local source="$1"
-    local item_key="$2"
-    [[ "$source" == "history" || "$source" == "runtime_history" || "$source" == "transition" ]] && [[ "$item_key" == *" "* ]]
+    # The daemon marks whole-line candidates authoritatively (TSV field 7 ->
+    # the _shac_menu_full_lines array). The widget no longer re-derives this
+    # from source/item_key heuristics, which used to drift from the daemon's
+    # own escaping decision (F3/F7/F8).
+    [[ "${_shac_menu_full_lines[$_shac_menu_selected_index]:-0}" == "1" ]]
   }
 
   function _shac_buffer_ends_with_space() {
@@ -729,6 +725,12 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
         _shac_menu_sources+=("$REPLY")
         _shac_decode "${fields[6]:-}"
         _shac_menu_descriptions+=("$REPLY")
+        # Field 7 is the daemon's authoritative full-line flag ("1"/"0").
+        # Absent from an older binary's 6-field rows -> defaults to "0" (a
+        # plain token) via the `:-0` fallback, matching the conservative
+        # serde default on the daemon side.
+        _shac_decode "${fields[7]:-0}"
+        _shac_menu_full_lines+=("${REPLY:-0}")
       fi
     done < <(
       TTY="$tty_value" shac complete \
@@ -963,12 +965,7 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
   function _shac_accept_line_widget() {
     _shac_clear_inline
     if (( _shac_menu_open )); then
-      local source item_key
-      _shac_selected_source
-      source="$REPLY"
-      _shac_selected_item_key
-      item_key="$REPLY"
-      if _shac_selected_is_full_line "$source" "$item_key"; then
+      if _shac_selected_is_full_line; then
         _shac_preexec_provenance="accepted_completion"
         _shac_preexec_provenance_source="unknown"
         _shac_preexec_provenance_confidence="unknown"

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -500,6 +500,16 @@ fn main() -> Result<()> {
             CompletionArgs::from_arg_matches(sub).unwrap_or_else(|e| e.exit()),
         ),
         Some(("record-command", sub)) => {
+            // Honor the kill-switch client-side: when shac is disabled, record
+            // nothing and don't even `ensure_daemon` (starting a daemon just to
+            // drop the record). The daemon caches `enabled` at startup, so
+            // relying on its gate alone left `config set enabled false`
+            // ineffective on a running daemon until restart — while completions
+            // went quiet client-side, so the user reasonably believed shac was
+            // off yet recording continued (review P1).
+            if shac_disabled(&paths)? {
+                return Ok(());
+            }
             ensure_daemon(&paths)?;
             let a = RecordArgs::from_arg_matches(sub).unwrap_or_else(|e| e.exit());
             send_request(
@@ -1910,19 +1920,24 @@ fn print_completion_response(
                 .and_then(|value| value.as_str())
                 .unwrap_or_default();
             let item_ctx = item_token_context(&ctx, typed_home_user, &item);
-            // The daemon is the single source of truth for whether a candidate
-            // is a whole command line (F3/F7/F8): a multi-word history/transition
-            // entry offered while the user completes the whole buffer from the
-            // start. Such a line replaces the buffer and is already valid shell,
-            // so per-token escaping (which would turn `cd ..` into `cd\ ..` — one
-            // broken word) must be skipped. Single-token candidates (paths,
-            // options, subcommands) are still escaped. The flag is emitted as
-            // field 7 so every widget keys insert/Enter off the same bit.
+            // Two daemon-computed bits, kept separate to avoid the drift F7/F8
+            // set out to kill. `verbatim`: the candidate is already a whole
+            // valid shell line (a multi-word history/transition entry at any
+            // command position — buffer start OR after `&&`/`|`/`;`), so
+            // per-token escaping (which turns `cd ..` into `cd\ ..`, one broken
+            // word) must be skipped. `full_line`: Enter may run it — only when
+            // it replaces the whole buffer — and is emitted as field 7 so every
+            // widget keys Enter/insert off the same bit. Single-token candidates
+            // (paths, options, subcommands) get neither and are escaped.
+            let verbatim = item
+                .get("verbatim")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             let full_line = item
                 .get("full_line")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            let quoted_insert = if full_line {
+            let quoted_insert = if verbatim {
                 insert_text.to_string()
             } else {
                 quote_token(shell, &item_ctx, insert_text)

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -1910,27 +1910,32 @@ fn print_completion_response(
                 .and_then(|value| value.as_str())
                 .unwrap_or_default();
             let item_ctx = item_token_context(&ctx, typed_home_user, &item);
-            // A whole command line resurrected from history/transitions (kind
-            // `history`/`command`, multi-word) replaces the buffer and is
-            // already valid shell — per-token escaping would turn `cd ..` into
-            // `cd\ ..` (one broken word that executes as "command not found: cd
-            // .."). Single-token candidates (paths, options, subcommands) are
-            // still escaped. Mirrors the widget's `_shac_selected_is_full_line`.
-            let is_full_line_command =
-                matches!(kind, "history" | "command") && item_key.contains(' ');
-            let quoted_insert = if is_full_line_command {
+            // The daemon is the single source of truth for whether a candidate
+            // is a whole command line (F3/F7/F8): a multi-word history/transition
+            // entry offered while the user completes the whole buffer from the
+            // start. Such a line replaces the buffer and is already valid shell,
+            // so per-token escaping (which would turn `cd ..` into `cd\ ..` — one
+            // broken word) must be skipped. Single-token candidates (paths,
+            // options, subcommands) are still escaped. The flag is emitted as
+            // field 7 so every widget keys insert/Enter off the same bit.
+            let full_line = item
+                .get("full_line")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let quoted_insert = if full_line {
                 insert_text.to_string()
             } else {
                 quote_token(shell, &item_ctx, insert_text)
             };
             println!(
-                "{}\t{}\t{}\t{}\t{}\t{}",
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
                 encode_field(item_key),
                 encode_field(&quoted_insert),
                 encode_field(display),
                 encode_field(kind),
                 encode_field(source),
-                encode_field(description)
+                encode_field(description),
+                if full_line { "1" } else { "0" }
             );
         }
         if let Some(tip) = response.get("tip").and_then(|v| v.as_object()) {

--- a/src/bin/shac.rs
+++ b/src/bin/shac.rs
@@ -2121,7 +2121,15 @@ fn shac_disabled(paths: &AppPaths) -> Result<bool> {
 
 fn request_timeout_for_action(action: &str, base_timeout_ms: u64) -> Duration {
     let timeout_ms = match action {
-        "reindex" => base_timeout_ms.max(1_500),
+        // `reindex` rescans every PATH command and rebuilds the doc index
+        // synchronously in the daemon; on a machine with a large PATH — or a
+        // slow CI runner — that legitimately takes several seconds. It is an
+        // explicit, occasional command, not a keystroke-latency path, so give
+        // the client a generous ceiling. A too-tight one makes the client
+        // report a "read daemon response" failure while the daemon is still
+        // working and actually finishing the reindex (the recurring CI flake
+        // in reindex_default_flags_succeeds / cli_daemon_records_*).
+        "reindex" => base_timeout_ms.max(30_000),
         "stats" | "migration-status" => base_timeout_ms.max(500),
         _ => base_timeout_ms.max(1),
     };
@@ -2377,6 +2385,27 @@ mod first_run_ux_tests {
         assert_eq!(fmt_count(1_000), "1,000");
         assert_eq!(fmt_count(12_847), "12,847");
         assert_eq!(fmt_count(1_234_567), "1,234,567");
+    }
+
+    #[test]
+    fn reindex_gets_a_generous_timeout_floor() {
+        // A tiny daemon_timeout_ms (the keystroke-latency default) must not
+        // bound a full-PATH reindex: the client would give up while the daemon
+        // is still working. reindex floors at 30s regardless.
+        assert_eq!(
+            request_timeout_for_action("reindex", 150),
+            Duration::from_millis(30_000)
+        );
+        // A larger configured timeout still wins if it exceeds the floor.
+        assert_eq!(
+            request_timeout_for_action("reindex", 45_000),
+            Duration::from_millis(45_000)
+        );
+        // Latency-sensitive actions keep their small ceilings.
+        assert_eq!(
+            request_timeout_for_action("complete", 150),
+            Duration::from_millis(150)
+        );
     }
 
     #[test]

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -62,10 +62,23 @@ fn main() -> Result<()> {
     let listener = UnixListener::bind(&paths.socket_file).context("bind unix socket")?;
     // The control socket is unauthenticated (any local peer can `complete`,
     // `stats`, or poison learning via `record-command`), so restrict it to the
-    // owner (F5). Best-effort chmod right after bind.
+    // owner (F5). Best-effort chmod right after bind, then verify the ACTUAL
+    // mode once at startup: if the chmod silently failed (exotic FS) and the
+    // 0700 state dir didn't shield it either, warn rather than leaving the
+    // channel quietly reachable by other local users.
     {
         use std::os::unix::fs::PermissionsExt;
         let _ = fs::set_permissions(&paths.socket_file, fs::Permissions::from_mode(0o600));
+        if let Ok(meta) = fs::metadata(&paths.socket_file) {
+            let mode = meta.permissions().mode() & 0o777;
+            if mode & 0o077 != 0 {
+                eprintln!(
+                    "shac: warning: control socket {} is group/other-accessible (mode {mode:o}); \
+                     other local users may be able to reach the daemon",
+                    paths.socket_file.display()
+                );
+            }
+        }
     }
     // Only claim the pid-file after a successful bind, so a bind failure
     // never leaves an orphaned pid-file pointing at a process that's about

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use clap::Parser;
 use shac::config::{AppConfig, AppPaths};
-use shac::db::{AppDb, COMPLETION_TELEMETRY_RETENTION_DAYS};
+use shac::db::{AppDb, COMPLETION_TELEMETRY_RETENTION_DAYS, HISTORY_RETENTION_DAYS};
 use shac::engine::Engine;
 use shac::indexer;
 use shac::protocol::RecordCommandRequest;
@@ -132,11 +132,25 @@ fn main() -> Result<()> {
                     // takes effect without restarting the daemon — this is
                     // the user-facing privacy control, it should be
                     // responsive.
-                    let retention_days = AppConfig::load(&config_paths)
+                    let config = AppConfig::load(&config_paths).ok();
+                    let telemetry_days = config
+                        .as_ref()
                         .map(|c| c.telemetry_retention_days as i64)
                         .unwrap_or(COMPLETION_TELEMETRY_RETENTION_DAYS);
-                    if let Err(e) = db.prune_completion_telemetry(retention_days) {
+                    if let Err(e) = db.prune_completion_telemetry(telemetry_days) {
                         eprintln!("shac: telemetry prune error: {e}");
+                    }
+                    // Also cap the recorded shell-command history so the DB
+                    // can't grow without bound over months of use. Same
+                    // reload-per-tick rationale as telemetry: `shac config set
+                    // history_retention_days ...` takes effect without a
+                    // daemon restart.
+                    let history_days = config
+                        .as_ref()
+                        .map(|c| c.history_retention_days as i64)
+                        .unwrap_or(HISTORY_RETENTION_DAYS);
+                    if let Err(e) = db.prune_history_events(history_days) {
+                        eprintln!("shac: history prune error: {e}");
                     }
                     // bg indexer never shells out to `<cmd> --help`; only
                     // records names + paths and seeds bundled static_docs.

--- a/src/bin/shacd.rs
+++ b/src/bin/shacd.rs
@@ -60,6 +60,13 @@ fn main() -> Result<()> {
         fs::remove_file(&paths.socket_file).ok();
     }
     let listener = UnixListener::bind(&paths.socket_file).context("bind unix socket")?;
+    // The control socket is unauthenticated (any local peer can `complete`,
+    // `stats`, or poison learning via `record-command`), so restrict it to the
+    // owner (F5). Best-effort chmod right after bind.
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&paths.socket_file, fs::Permissions::from_mode(0o600));
+    }
     // Only claim the pid-file after a successful bind, so a bind failure
     // never leaves an orphaned pid-file pointing at a process that's about
     // to exit.

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,12 @@ pub struct AppConfig {
     /// diagnostics. There is no learner reading this data anymore, so the
     /// only trade-off is diagnostics depth vs. how long local data lingers.
     pub telemetry_retention_days: u32,
+    /// How many days of recorded shell-command history (`history_events`) the
+    /// background prune keeps. This is the corpus that powers history-based
+    /// completion and learned command transitions, so it defaults high (one
+    /// year) to keep suggestions useful; `0` prunes everything each cycle for
+    /// users who don't want persistent history at all.
+    pub history_retention_days: u32,
 }
 
 impl Default for AppConfig {
@@ -136,6 +142,7 @@ impl Default for AppConfig {
             max_results: 12,
             daemon_timeout_ms: 150,
             telemetry_retention_days: 30,
+            history_retention_days: 365,
         }
     }
 }
@@ -227,6 +234,7 @@ impl AppConfig {
             "max_results" => Some(self.max_results.to_string()),
             "daemon_timeout_ms" => Some(self.daemon_timeout_ms.to_string()),
             "telemetry_retention_days" => Some(self.telemetry_retention_days.to_string()),
+            "history_retention_days" => Some(self.history_retention_days.to_string()),
             "ranking.prefix_score" => Some(self.ranking.prefix_score.to_string()),
             "ranking.fuzzy_score" => Some(self.ranking.fuzzy_score.to_string()),
             "ranking.global_usage_score" => Some(self.ranking.global_usage_score.to_string()),
@@ -265,6 +273,7 @@ impl AppConfig {
             "max_results" => self.max_results = value.parse()?,
             "daemon_timeout_ms" => self.daemon_timeout_ms = value.parse()?,
             "telemetry_retention_days" => self.telemetry_retention_days = value.parse()?,
+            "history_retention_days" => self.history_retention_days = value.parse()?,
             "ranking.prefix_score" => self.ranking.prefix_score = value.parse()?,
             "ranking.fuzzy_score" => self.ranking.fuzzy_score = value.parse()?,
             "ranking.global_usage_score" => self.ranking.global_usage_score = value.parse()?,
@@ -337,8 +346,17 @@ mod tests {
         // its chmod is skipped without error.
         paths.ensure().expect("ensure creates dirs");
         for dir in [&config_dir, &data_dir, &state_dir] {
-            let mode = fs::metadata(dir).expect("dir metadata").permissions().mode() & 0o777;
-            assert_eq!(mode, 0o700, "{} should be 0700, got {mode:o}", dir.display());
+            let mode = fs::metadata(dir)
+                .expect("dir metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                mode,
+                0o700,
+                "{} should be 0700, got {mode:o}",
+                dir.display()
+            );
         }
 
         // Simulate a pre-existing history DB with loose perms, then re-run
@@ -396,5 +414,45 @@ mod tests {
         let raw = toml::to_string_pretty(&config).expect("serialize config");
         let parsed: AppConfig = toml::from_str(&raw).expect("parse config");
         assert_eq!(parsed.telemetry_retention_days, 7);
+    }
+
+    #[test]
+    fn history_retention_days_defaults_to_365() {
+        assert_eq!(AppConfig::default().history_retention_days, 365);
+    }
+
+    #[test]
+    fn history_retention_days_get_set_roundtrip() {
+        let mut config = AppConfig::default();
+        assert_eq!(
+            config.get_key("history_retention_days").as_deref(),
+            Some("365")
+        );
+
+        config
+            .set_key("history_retention_days", "0")
+            .expect("set to 0 (no persistent history)");
+        assert_eq!(config.history_retention_days, 0);
+
+        config
+            .set_key("history_retention_days", "730")
+            .expect("set to 730");
+        assert_eq!(config.history_retention_days, 730);
+
+        assert!(
+            config.set_key("history_retention_days", "-5").is_err(),
+            "negative retention must be rejected"
+        );
+    }
+
+    #[test]
+    fn history_retention_days_survives_toml_roundtrip() {
+        let config = AppConfig {
+            history_retention_days: 90,
+            ..AppConfig::default()
+        };
+        let raw = toml::to_string_pretty(&config).expect("serialize config");
+        let parsed: AppConfig = toml::from_str(&raw).expect("parse config");
+        assert_eq!(parsed.history_retention_days, 90);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,10 +181,22 @@ impl AppPaths {
     }
 
     pub fn ensure(&self) -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
         fs::create_dir_all(&self.config_dir).context("create config dir")?;
         fs::create_dir_all(&self.data_dir).context("create data dir")?;
         fs::create_dir_all(&self.state_dir).context("create state dir")?;
         fs::create_dir_all(&self.shell_dir).context("create shell dir")?;
+        // These dirs hold the command-history DB and the control socket. A
+        // world-traversable dir would let another local user read the entire
+        // shell history or connect to the unauthenticated socket (F5). chmod is
+        // best-effort — ignore on filesystems that don't support unix modes.
+        for dir in [&self.config_dir, &self.data_dir, &self.state_dir] {
+            let _ = fs::set_permissions(dir, fs::Permissions::from_mode(0o700));
+        }
+        // The history DB itself, 0600 (defense in depth beyond the 0700 dir).
+        if self.db_file.exists() {
+            let _ = fs::set_permissions(&self.db_file, fs::Permissions::from_mode(0o600));
+        }
         Ok(())
     }
 }
@@ -301,6 +313,46 @@ fn parse_bool(value: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ensure_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let base = tmp.path();
+        let config_dir = base.join("config");
+        let data_dir = base.join("data");
+        let state_dir = base.join("state");
+        let paths = AppPaths {
+            config_file: config_dir.join("config.toml"),
+            db_file: data_dir.join("shac.db"),
+            socket_file: state_dir.join("shacd.sock"),
+            pid_file: state_dir.join("shacd.pid"),
+            shell_dir: config_dir.join("shell"),
+            config_dir: config_dir.clone(),
+            data_dir: data_dir.clone(),
+            state_dir: state_dir.clone(),
+        };
+
+        // First ensure: dirs are created 0700. The db doesn't exist yet, so
+        // its chmod is skipped without error.
+        paths.ensure().expect("ensure creates dirs");
+        for dir in [&config_dir, &data_dir, &state_dir] {
+            let mode = fs::metadata(dir).expect("dir metadata").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "{} should be 0700, got {mode:o}", dir.display());
+        }
+
+        // Simulate a pre-existing history DB with loose perms, then re-run
+        // ensure: it must tighten the db to 0600 (F5 defense in depth).
+        fs::write(&paths.db_file, b"x").expect("seed db");
+        fs::set_permissions(&paths.db_file, fs::Permissions::from_mode(0o644)).expect("loosen db");
+        paths.ensure().expect("ensure tightens db perms");
+        let db_mode = fs::metadata(&paths.db_file)
+            .expect("db metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(db_mode, 0o600, "db file should be 0600, got {db_mode:o}");
+    }
 
     #[test]
     fn telemetry_retention_days_defaults_to_30() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -29,7 +29,7 @@ pub fn parse(line: &str, cursor: usize, cwd: &Path) -> ParsedContext {
     // Only the pipeline/list segment the cursor is in determines the command:
     // completion after `|`, `&&`, `;`, `&`, or a redirection targets the
     // command that starts that segment, not the one at the start of the line.
-    let segment = last_segment(&before);
+    let (segment, redirect_segment) = last_segment(&before);
     let scanned = tokenize(&segment);
     let mut tokens = scanned.tokens;
 
@@ -48,7 +48,7 @@ pub fn parse(line: &str, cursor: usize, cwd: &Path) -> ParsedContext {
     } else {
         None
     };
-    let role = classify_role(&tokens, active_index, cwd);
+    let role = classify_role(&tokens, active_index, cwd, redirect_segment);
     let project_markers = detect_project_markers(cwd);
 
     ParsedContext {
@@ -68,11 +68,17 @@ pub fn parse(line: &str, cursor: usize, cwd: &Path) -> ParsedContext {
 /// pipeline/list operator (`|`, `||`, `&&`, `;`, `&`) or redirection (`<`,
 /// `>`), so callers can restrict tokenization to the segment containing the
 /// cursor. Operators inside an open quote are not boundaries. 0 if none.
-fn last_segment_start(s: &str) -> usize {
+/// Returns the char index in `s` immediately after the last unquoted operator,
+/// plus whether that operator was a redirection (`<`/`>`) rather than a
+/// pipeline/list operator (`|`/`||`/`&&`/`;`/`&`). The redirect flag lets the
+/// caller classify the segment's target token as a filename path instead of a
+/// command (F3).
+fn last_segment_start(s: &str) -> (usize, bool) {
     let chars: Vec<char> = s.chars().collect();
     let mut quote: Option<char> = None;
     let mut escaped = false;
     let mut boundary = 0usize;
+    let mut redirect = false;
     let mut i = 0;
 
     while i < chars.len() {
@@ -93,30 +99,44 @@ fn last_segment_start(s: &str) -> usize {
             }
             '|' | '&' | ';' | '<' | '>' if quote.is_none() => {
                 // Treat a doubled operator ("||", "&&") as a single boundary.
+                // ">>"/"<<" need no special-casing: each char sets the boundary
+                // and the redirect flag, so the pair lands past both.
                 if matches!(ch, '|' | '&') && chars.get(i + 1) == Some(&ch) {
                     i += 1;
                 }
                 boundary = i + 1;
+                redirect = matches!(ch, '<' | '>');
             }
             _ => {}
         }
         i += 1;
     }
-    boundary
+    (boundary, redirect)
 }
 
 /// The trailing pipeline/list segment of `s` (the part after the last
-/// top-level operator), or the whole string if there is none.
-fn last_segment(s: &str) -> String {
-    let start = last_segment_start(s);
-    s.chars().skip(start).collect()
+/// top-level operator), plus whether that operator was a redirection.
+fn last_segment(s: &str) -> (String, bool) {
+    let (start, redirect) = last_segment_start(s);
+    (s.chars().skip(start).collect(), redirect)
 }
 
-fn classify_role(tokens: &[String], active_index: usize, cwd: &Path) -> TokenRole {
+fn classify_role(
+    tokens: &[String],
+    active_index: usize,
+    cwd: &Path,
+    redirect_target: bool,
+) -> TokenRole {
     let token = tokens
         .get(active_index)
         .map(String::as_str)
         .unwrap_or_default();
+    // The first token after a redirection is the file the stream is wired to,
+    // not a command — complete it as a path even though it sits at index 0 of
+    // its segment (F3). `> fi<Tab>` should offer filenames, not commands.
+    if redirect_target && active_index == 0 {
+        return TokenRole::Path;
+    }
     if active_index == 0 {
         return TokenRole::Command;
     }
@@ -299,5 +319,26 @@ mod tests {
         let q = parse("cd \"My ", 7, cwd);
         assert_eq!(q.active_token, "My ");
         assert_eq!(q.open_quote, Some('"'));
+    }
+
+    #[test]
+    fn redirect_target_is_path_not_command() {
+        let cwd = std::path::Path::new("/tmp");
+        // `cat > fi` — the token after `>` is a filename, so it must classify
+        // as Path (offering file completion), not Command (F3).
+        let out = parse("cat > fi", 8, cwd);
+        assert_eq!(out.active_token, "fi");
+        assert_eq!(out.role, TokenRole::Path);
+
+        // Input redirection and append behave the same.
+        assert_eq!(parse("sort < in", 9, cwd).role, TokenRole::Path);
+        assert_eq!(parse("echo hi >> lo", 13, cwd).role, TokenRole::Path);
+
+        // An empty target right after the operator still wants file completion.
+        assert_eq!(parse("cat > ", 6, cwd).role, TokenRole::Path);
+
+        // A pipeline boundary is NOT a redirect: the segment head stays a
+        // command so `... | gr` still completes command names.
+        assert_eq!(parse("cat foo | gr", 12, cwd).role, TokenRole::Command);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -97,15 +97,39 @@ fn last_segment_start(s: &str) -> (usize, bool) {
                     quote = Some(ch);
                 }
             }
-            '|' | '&' | ';' | '<' | '>' if quote.is_none() => {
+            '<' if quote.is_none() => {
+                // `<<` (heredoc) / `<<<` (here-string): the following word is a
+                // delimiter/string, NOT a filename, so don't classify it as a
+                // path. A single `<` is a real input redirection.
+                if chars.get(i + 1) == Some(&'<') {
+                    while chars.get(i + 1) == Some(&'<') {
+                        i += 1;
+                    }
+                    boundary = i + 1;
+                    redirect = false;
+                } else {
+                    boundary = i + 1;
+                    redirect = true;
+                }
+            }
+            '>' if quote.is_none() => {
+                // `>|` (zsh clobber-override) is still a file redirect; consume
+                // the `|` so it isn't later treated as a pipe boundary. `>>`
+                // (append) needs no special-casing — the second `>` re-sets the
+                // boundary and keeps `redirect` true.
+                if chars.get(i + 1) == Some(&'|') {
+                    i += 1;
+                }
+                boundary = i + 1;
+                redirect = true;
+            }
+            '|' | '&' | ';' if quote.is_none() => {
                 // Treat a doubled operator ("||", "&&") as a single boundary.
-                // ">>"/"<<" need no special-casing: each char sets the boundary
-                // and the redirect flag, so the pair lands past both.
                 if matches!(ch, '|' | '&') && chars.get(i + 1) == Some(&ch) {
                     i += 1;
                 }
                 boundary = i + 1;
-                redirect = matches!(ch, '<' | '>');
+                redirect = false;
             }
             _ => {}
         }
@@ -238,6 +262,12 @@ fn tokenize(line: &str) -> Tokenized {
             continue;
         }
         match ch {
+            // NB: `\` escapes even inside single quotes here, which POSIX
+            // doesn't (in `'a\'` the quote closes at the second `'`). This is
+            // deliberate: the zsh/bash widget span walkers mirror this exact
+            // rule, so the region a widget replaces always matches the token
+            // the daemon completed. Being self-consistent matters more than
+            // POSIX-strictness for an obscure literal-backslash-in-quotes case.
             '\\' => escaped = true,
             '\'' | '"' => {
                 if quote == Some(ch) {
@@ -340,5 +370,13 @@ mod tests {
         // A pipeline boundary is NOT a redirect: the segment head stays a
         // command so `... | gr` still completes command names.
         assert_eq!(parse("cat foo | gr", 12, cwd).role, TokenRole::Command);
+
+        // `>|` (zsh clobber-override) is still a file redirect.
+        assert_eq!(parse("echo hi >| ou", 13, cwd).role, TokenRole::Path);
+
+        // Heredoc `<<` / here-string `<<<` targets are delimiters/words, NOT
+        // files — they must NOT become a Path (no bogus file completion).
+        assert_ne!(parse("cat << EO", 9, cwd).role, TokenRole::Path);
+        assert_ne!(parse("sort <<< wor", 12, cwd).role, TokenRole::Path);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,6 +28,12 @@ const TRANSITION_MAX_GAP_SECS: i64 = 600;
 /// other pruning, so inline mode can write tens of MB/day without this cap.
 pub const COMPLETION_TELEMETRY_RETENTION_DAYS: i64 = 30;
 
+/// Default retention window for recorded shell-command history
+/// (`history_events`). This is the corpus behind history completion and
+/// learned transitions, so it defaults to a full year — long enough for
+/// suggestions to stay useful, but still bounded so the DB can't grow forever.
+pub const HISTORY_RETENTION_DAYS: i64 = 365;
+
 #[derive(Debug, Clone)]
 pub struct StoredDoc {
     pub command: String,
@@ -613,11 +619,17 @@ impl AppDb {
             }
 
             let _ = self.mark_completion_accepted(&request.command, &request.cwd, &classified);
-        }
 
-        // Hybrid-cd: extract `cd <path>` events into paths_index for global frecency.
-        if let Some(target) = extract_cd_target(&request.command) {
-            let _ = self.upsert_path_index(&target, "cwd_event", false, None);
+            // Hybrid-cd: extract `cd <path>` events into paths_index for
+            // global frecency. Gated on the same clean-personalization signal
+            // as transitions/profiles (F4) so pasted or legacy/imported `cd`s
+            // don't seed path-jump suggestions from directories the user never
+            // actually navigated to interactively. Bulk import seeds
+            // paths_index through its own path (see import.rs), so cold-start
+            // frecency is unaffected.
+            if let Some(target) = extract_cd_target(&request.command) {
+                let _ = self.upsert_path_index(&target, "cwd_event", false, None);
+            }
         }
 
         Ok(classified)
@@ -1473,6 +1485,21 @@ impl AppDb {
                 params![cutoff],
             )
             .context("prune completion telemetry")?;
+        Ok(deleted)
+    }
+
+    /// Deletes `history_events` rows older than `retention_days` (the
+    /// configured `history_retention_days`, default [`HISTORY_RETENTION_DAYS`]).
+    /// This is the recorded shell-command corpus behind history completion and
+    /// learned transitions. `retention_days <= 0` prunes everything on the next
+    /// cycle, for users who don't want persistent history at all. Returns the
+    /// number of rows pruned.
+    pub fn prune_history_events(&self, retention_days: i64) -> Result<usize> {
+        let cutoff = unix_ts() - retention_days.max(0) * 86_400;
+        let deleted = self
+            .conn
+            .execute("DELETE FROM history_events WHERE ts < ?1", params![cutoff])
+            .context("prune history events")?;
         Ok(deleted)
     }
 
@@ -2513,6 +2540,56 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM completion_requests", [], |r| r.get(0))
             .unwrap();
         assert_eq!(remaining_requests, 0);
+    }
+
+    #[test]
+    fn prune_history_events_removes_old_keeps_recent() {
+        let db = test_db();
+        let now = unix_ts();
+        // One row older than the 365-day default window, one recent.
+        for (ts, cmd) in [(now - 400 * 86_400, "ls -old"), (now - 1, "ls -recent")] {
+            db.conn
+                .execute(
+                    "INSERT INTO history_events(ts, cwd, command) VALUES (?1, '/tmp', ?2)",
+                    params![ts, cmd],
+                )
+                .expect("insert history");
+        }
+
+        let deleted = db.prune_history_events(365).expect("prune history");
+        assert_eq!(deleted, 1, "only the 400-day-old row is pruned");
+
+        let surviving: Vec<String> = db
+            .conn
+            .prepare("SELECT command FROM history_events ORDER BY ts")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(surviving, vec!["ls -recent".to_string()]);
+    }
+
+    /// `history_retention_days = 0` prunes everything on the next cycle, for
+    /// users who don't want any persistent shell history.
+    #[test]
+    fn prune_history_events_zero_retention_prunes_everything() {
+        let db = test_db();
+        let now = unix_ts();
+        db.conn
+            .execute(
+                "INSERT INTO history_events(ts, cwd, command) VALUES (?1, '/tmp', 'ls')",
+                params![now - 1],
+            )
+            .expect("insert history");
+
+        let deleted = db.prune_history_events(0).expect("prune");
+        assert_eq!(deleted, 1);
+        let remaining: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM history_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(remaining, 0);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1494,11 +1494,24 @@ impl AppDb {
     /// learned transitions. `retention_days <= 0` prunes everything on the next
     /// cycle, for users who don't want persistent history at all. Returns the
     /// number of rows pruned.
+    ///
+    /// Retention is measured from whichever clock is more recent: the command's
+    /// own timestamp (live rows) or when it entered our DB (`imported_at`, for
+    /// imported rows). Plain (non-`EXTENDED_HISTORY`) zsh history — the zsh
+    /// default — carries no timestamps, so `import` stores `ts = 0` and keeps
+    /// the real clock in `imported_at`. Pruning on `ts` alone would delete the
+    /// entire imported corpus on the first tick (and re-arm on every re-import,
+    /// since the `import_hash` rows vanish with it). A row survives while
+    /// EITHER clock is inside the window.
     pub fn prune_history_events(&self, retention_days: i64) -> Result<usize> {
         let cutoff = unix_ts() - retention_days.max(0) * 86_400;
         let deleted = self
             .conn
-            .execute("DELETE FROM history_events WHERE ts < ?1", params![cutoff])
+            .execute(
+                "DELETE FROM history_events
+                 WHERE ts < ?1 AND (imported_at IS NULL OR imported_at < ?1)",
+                params![cutoff],
+            )
             .context("prune history events")?;
         Ok(deleted)
     }
@@ -2568,6 +2581,45 @@ mod tests {
             .collect::<rusqlite::Result<Vec<_>>>()
             .unwrap();
         assert_eq!(surviving, vec!["ls -recent".to_string()]);
+    }
+
+    /// Plain (non-EXTENDED) zsh history imports store `ts = 0` with the real
+    /// clock in `imported_at`. Retention must key off `imported_at` for those,
+    /// or a single prune tick wipes the whole imported corpus. Recently-imported
+    /// zero-ts rows survive; a stale import (imported > window ago) is pruned.
+    #[test]
+    fn prune_history_events_keeps_recently_imported_zero_ts() {
+        let db = test_db();
+        let now = unix_ts();
+        for (ts, imported_at, cmd) in [
+            (0_i64, now - 1, "imported-fresh"), // zero ts, just imported
+            (0_i64, now - 400 * 86_400, "imported-stale"), // imported > 365d ago
+        ] {
+            db.conn
+                .execute(
+                    "INSERT INTO history_events(ts, cwd, command, imported_at)
+                     VALUES (?1, '/tmp', ?2, ?3)",
+                    params![ts, cmd, imported_at],
+                )
+                .expect("insert imported history");
+        }
+
+        let deleted = db.prune_history_events(365).expect("prune history");
+        assert_eq!(deleted, 1, "only the stale import is pruned");
+
+        let surviving: Vec<String> = db
+            .conn
+            .prepare("SELECT command FROM history_events")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            surviving,
+            vec!["imported-fresh".to_string()],
+            "a freshly imported zero-ts row must survive retention"
+        );
     }
 
     /// `history_retention_days = 0` prunes everything on the next cycle, for

--- a/src/db.rs
+++ b/src/db.rs
@@ -108,6 +108,12 @@ impl AppDb {
         let conn = Connection::open(path).context("open sqlite db")?;
         conn.busy_timeout(Duration::from_millis(1_000))
             .context("set sqlite busy timeout")?;
+        // The command-history DB must not be world-readable (F5). Best-effort
+        // (no-op for the `:memory:` test db, which has no backing file).
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        }
         let db = Self { conn };
         db.init()?;
         Ok(db)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -306,6 +306,19 @@ impl Engine {
     }
 
     pub fn record_command(&self, request: RecordCommandRequest) -> Result<()> {
+        // Global kill-switch: when the user has disabled shac, persist nothing
+        // — no history, transitions, project profiles, or cd frecency (F4).
+        if !self.config.enabled {
+            return Ok(());
+        }
+        // Privacy convention mirroring bash `HISTCONTROL=ignorespace` / zsh
+        // `HIST_IGNORE_SPACE`: a command the user prefixed with a space (or
+        // tab) is intentionally ephemeral. Skip recording it entirely so a
+        // secret-bearing ` export TOKEN=...` or ` cd /private` never lands in
+        // history or the cd index (F4).
+        if request.command.starts_with(' ') || request.command.starts_with('\t') {
+            return Ok(());
+        }
         self.db.record_history(&request)?;
         Ok(())
     }
@@ -3184,6 +3197,67 @@ mod tests {
         };
         let engine = Engine::new(&paths).expect("engine");
         (engine, dir)
+    }
+
+    fn record_req(command: &str, cwd: &str) -> crate::protocol::RecordCommandRequest {
+        // Interactive typed_manual hints so the event classifies as a clean
+        // signal that `latest_command` will return (it filters to
+        // interactive/typed rows), letting the test observe whether recording
+        // happened at all.
+        crate::protocol::RecordCommandRequest {
+            command: command.to_string(),
+            cwd: cwd.to_string(),
+            shell: Some("zsh".to_string()),
+            trust: Some("interactive".to_string()),
+            provenance: Some("typed_manual".to_string()),
+            provenance_source: None,
+            provenance_confidence: None,
+            origin: Some("zsh_precmd".to_string()),
+            tty_present: Some(true),
+            exit_status: Some(0),
+            accepted_request_id: None,
+            accepted_item_key: None,
+            accepted_rank: None,
+        }
+    }
+
+    #[test]
+    fn record_command_skips_leading_space_commands() {
+        let (engine, _dir) = test_engine("rec-ignorespace");
+        // A space-prefixed command is intentionally ephemeral (HISTCONTROL
+        // ignorespace convention) — it must not be persisted.
+        engine
+            .record_command(record_req(" secret --token=abc", "/tmp"))
+            .expect("record");
+        assert_eq!(
+            engine.db.latest_command().expect("latest"),
+            None,
+            "a leading-space command must not be recorded"
+        );
+
+        // A normal command is recorded as usual.
+        engine
+            .record_command(record_req("ls -la", "/tmp"))
+            .expect("record");
+        assert_eq!(
+            engine.db.latest_command().expect("latest").as_deref(),
+            Some("ls -la"),
+            "a normal command is recorded"
+        );
+    }
+
+    #[test]
+    fn record_command_skips_when_disabled() {
+        let (mut engine, _dir) = test_engine("rec-disabled");
+        engine.config.enabled = false;
+        engine
+            .record_command(record_req("ls -la", "/tmp"))
+            .expect("record");
+        assert_eq!(
+            engine.db.latest_command().expect("latest"),
+            None,
+            "nothing is recorded while shac is disabled"
+        );
     }
 
     fn make_request(line: &str, cwd: &str) -> CompletionRequest {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,11 +1,10 @@
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Hard timeout on the `git for-each-ref` invocation that backs
 /// `collect_git_branch_candidates`. Branch completion is best-effort —
@@ -366,13 +365,22 @@ impl Engine {
         // user overrides at <config_dir>/locales/<lang>.toml are picked up.
         // Future work: invalidate when override file mtime changes.
         let catalog = {
+            // Cap distinct cached locales so a client spamming unique
+            // SHAC_LOCALE values can't grow daemon memory without bound (F5).
+            // The real working set is a handful of locales, so the cap is
+            // effectively never reached in normal use; once full we serve
+            // fresh builds without caching rather than evicting.
+            const MAX_CATALOG_CACHE: usize = 64;
             let mut cache = self.catalog_cache.lock().unwrap_or_else(|e| e.into_inner());
-            cache
-                .entry(resolved.lang.clone())
-                .or_insert_with(|| {
-                    crate::i18n::Catalog::build(&self.paths.config_dir, &resolved.lang)
-                })
-                .clone()
+            if let Some(hit) = cache.get(&resolved.lang) {
+                hit.clone()
+            } else {
+                let built = crate::i18n::Catalog::build(&self.paths.config_dir, &resolved.lang);
+                if cache.len() < MAX_CATALOG_CACHE {
+                    cache.insert(resolved.lang.clone(), built.clone());
+                }
+                built
+            }
         };
         crate::i18n::Translator::new(resolved.lang, catalog)
     }
@@ -1937,8 +1945,8 @@ fn find_git_repo_root(start: &Path) -> Option<PathBuf> {
 /// The returned vector is deduped (some refs appear under both heads and
 /// remotes/origin) and capped at [`GIT_REF_MAX`].
 fn list_git_refs(repo_root: &Path, timeout: Duration) -> Option<Vec<String>> {
-    let mut child = Command::new("git")
-        .arg("-C")
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
         .arg(repo_root)
         .args([
             "for-each-ref",
@@ -1947,41 +1955,13 @@ fn list_git_refs(repo_root: &Path, timeout: Duration) -> Option<Vec<String>> {
             "refs/heads",
             "refs/remotes",
         ])
-        .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-        .ok()?;
-
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return None;
-                }
-                break;
-            }
-            Ok(None) => {
-                if started.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return None;
-                }
-                thread::sleep(Duration::from_millis(5));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return None;
-            }
-        }
+        .stdin(Stdio::null());
+    let output = crate::proc::run_capture(cmd, timeout)?;
+    if !output.success {
+        return None;
     }
-
-    let mut buf = String::new();
-    if let Some(mut out) = child.stdout.take() {
-        out.read_to_string(&mut buf).ok()?;
-    }
+    let buf = String::from_utf8_lossy(&output.stdout);
 
     let mut seen = HashSet::new();
     let mut refs = Vec::new();
@@ -2032,48 +2012,15 @@ fn list_kubectl_resources(timeout: Duration) -> Vec<String> {
         return Vec::new();
     }
 
-    let mut child = match Command::new("kubectl")
-        .args(["api-resources", "--no-headers", "--output=name"])
-        .stdout(Stdio::piped())
+    let mut cmd = Command::new("kubectl");
+    cmd.args(["api-resources", "--no-headers", "--output=name"])
         .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => return Vec::new(),
+        .stdin(Stdio::null());
+    let output = match crate::proc::run_capture(cmd, timeout) {
+        Some(output) if output.success => output,
+        _ => return Vec::new(),
     };
-
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return Vec::new();
-                }
-                break;
-            }
-            Ok(None) => {
-                if started.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Vec::new();
-                }
-                thread::sleep(Duration::from_millis(10));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Vec::new();
-            }
-        }
-    }
-
-    let mut buf = String::new();
-    if let Some(mut out) = child.stdout.take() {
-        if out.read_to_string(&mut buf).is_err() {
-            return Vec::new();
-        }
-    }
+    let buf = String::from_utf8_lossy(&output.stdout);
 
     buf.lines()
         .map(str::trim)
@@ -2088,48 +2035,16 @@ fn list_kubectl_resources(timeout: Duration) -> Vec<String> {
 /// `<none>` are skipped. Returns an empty `Vec` when docker is unavailable,
 /// the daemon is not running, or the command exits non-zero.
 fn list_docker_images() -> Vec<String> {
-    let mut child = match Command::new("docker")
-        .args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
-        .stdout(Stdio::piped())
+    let mut cmd = Command::new("docker");
+    cmd.args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
         .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
+        .stdin(Stdio::null());
+    let output = match crate::proc::run_capture(cmd, DOCKER_TIMEOUT) {
+        Some(output) if output.success => output,
+        _ => return Vec::new(),
     };
 
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return Vec::new();
-                }
-                break;
-            }
-            Ok(None) => {
-                if started.elapsed() >= DOCKER_TIMEOUT {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Vec::new();
-                }
-                thread::sleep(Duration::from_millis(5));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Vec::new();
-            }
-        }
-    }
-
-    let mut buf = String::new();
-    if let Some(mut out) = child.stdout.take() {
-        out.read_to_string(&mut buf).ok();
-    }
-
-    parse_docker_images_output(&buf)
+    parse_docker_images_output(&String::from_utf8_lossy(&output.stdout))
 }
 
 /// Parse raw `docker images` output (one `repo:tag` per line) into a deduplicated
@@ -2164,48 +2079,16 @@ fn parse_docker_images_output(output: &str) -> Vec<String> {
 /// docker is unavailable, the daemon is not running, or the command exits
 /// non-zero.
 fn list_docker_containers() -> Vec<String> {
-    let mut child = match Command::new("docker")
-        .args(["ps", "--format", "{{.Names}}"])
-        .stdout(Stdio::piped())
+    let mut cmd = Command::new("docker");
+    cmd.args(["ps", "--format", "{{.Names}}"])
         .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
+        .stdin(Stdio::null());
+    let output = match crate::proc::run_capture(cmd, DOCKER_TIMEOUT) {
+        Some(output) if output.success => output,
+        _ => return Vec::new(),
     };
 
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return Vec::new();
-                }
-                break;
-            }
-            Ok(None) => {
-                if started.elapsed() >= DOCKER_TIMEOUT {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Vec::new();
-                }
-                thread::sleep(Duration::from_millis(5));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Vec::new();
-            }
-        }
-    }
-
-    let mut buf = String::new();
-    if let Some(mut out) = child.stdout.take() {
-        out.read_to_string(&mut buf).ok();
-    }
-
-    parse_docker_containers_output(&buf)
+    parse_docker_containers_output(&String::from_utf8_lossy(&output.stdout))
 }
 
 /// Parse raw `docker ps` output (one container name per line) into a Vec,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -217,21 +217,29 @@ impl Engine {
         items.sort_by(|left, right| cmp_score(right.item.score, left.item.score));
         items.truncate(self.config.max_results);
 
-        // Mark whole-line candidates (F3/F7/F8). A history/transition entry is
-        // a full command line only when the user is completing the whole buffer
-        // from the start — the active token spans the entire (trimmed) line and
-        // the cursor is at the end — so replacing the token replaces the buffer.
-        // In any other position `project_history_candidate` already returns a
-        // single token, which must stay a per-token insert. Erring toward
-        // `false` is safe: a missed full-line just makes Enter insert instead of
-        // run; a false full-line would run a half-built command.
-        if whole_line_replacement_context(&req, &parsed) {
-            for item in &mut items {
-                item.item.full_line = matches!(
-                    item.item.source.as_str(),
-                    "history" | "runtime_history" | "transition"
-                ) && item.item.insert_text.contains(' ');
-            }
+        // Mark whole-line candidates (F3/F7/F8). Two distinct facts, computed
+        // once by the daemon so client and widgets can't drift:
+        //   * `verbatim` — the candidate is a whole shell line already, so the
+        //     CLI must NOT per-token escape it. `project_history_candidate`
+        //     returns the whole entry whenever the active token is at COMMAND
+        //     position, which recurs after every `&&`/`|`/`;`, not just at
+        //     buffer start.
+        //   * `full_line` — Enter may RUN it, which is only safe when it also
+        //     replaces the entire buffer (active token spans the whole trimmed
+        //     line, cursor at end). Strict subset of `verbatim`.
+        // Erring toward `false` is safe on both: no escaping change / Enter
+        // inserts. A false `full_line` (run a half-command) is the only
+        // dangerous direction, and it can't happen — it requires the whole
+        // buffer to be the single history token.
+        let command_role = matches!(parsed.role, TokenRole::Command);
+        let whole_line = whole_line_replacement_context(&req, &parsed);
+        for item in &mut items {
+            let whole_entry = matches!(
+                item.item.source.as_str(),
+                "history" | "runtime_history" | "transition"
+            ) && item.item.insert_text.contains(char::is_whitespace);
+            item.item.verbatim = command_role && whole_entry;
+            item.item.full_line = whole_line && whole_entry;
         }
 
         let response_sources: Vec<String> = items.iter().map(|i| i.item.source.clone()).collect();
@@ -326,7 +334,14 @@ impl Engine {
     pub fn record_command(&self, request: RecordCommandRequest) -> Result<()> {
         // Global kill-switch: when the user has disabled shac, persist nothing
         // — no history, transitions, project profiles, or cd frecency (F4).
-        if !self.config.enabled {
+        // Reloaded from disk per record (a tiny TOML read; this path is
+        // fire-and-forget, not keystroke-latency-sensitive) so `config set
+        // enabled false` takes effect on a running daemon without a restart,
+        // and a direct-socket client can't bypass the CLI's own gate (review).
+        let enabled = AppConfig::load(&self.paths)
+            .map(|c| c.enabled)
+            .unwrap_or(self.config.enabled);
+        if !enabled {
             return Ok(());
         }
         // Privacy convention mirroring bash `HISTCONTROL=ignorespace` / zsh
@@ -392,28 +407,37 @@ impl Engine {
                 .cloned()
                 .or_else(|| std::env::var("LANG").ok()),
         );
-        // Build (or fetch from cache) a catalog for this exact locale so
-        // user overrides at <config_dir>/locales/<lang>.toml are picked up.
+        // Cache/build key: an UNSAFE locale (path-shaped, or absurdly long —
+        // `normalize` bounds neither length nor `/`) collapses to `en`. Without
+        // this, a client spamming distinct hostile `SHAC_LOCALE` values would
+        // fill the cache with up-to-1-MiB keys that each only map to the `en`
+        // fallback anyway (F5 — the count cap bounds entries, not bytes). A
+        // safe token is a real locale (`en`, `pt-BR`) and keys itself.
+        let lang: &str = if crate::i18n::Catalog::is_safe_lang_check(&resolved.lang) {
+            &resolved.lang
+        } else {
+            "en"
+        };
+        // Build (or fetch from cache) a catalog for this locale so user
+        // overrides at <config_dir>/locales/<lang>.toml are picked up.
         // Future work: invalidate when override file mtime changes.
         let catalog = {
-            // Cap distinct cached locales so a client spamming unique
-            // SHAC_LOCALE values can't grow daemon memory without bound (F5).
-            // The real working set is a handful of locales, so the cap is
-            // effectively never reached in normal use; once full we serve
-            // fresh builds without caching rather than evicting.
+            // Cap distinct cached locales so a client spamming unique locales
+            // can't grow daemon memory without bound (F5). The real working set
+            // is a handful; once full we serve fresh builds without caching.
             const MAX_CATALOG_CACHE: usize = 64;
             let mut cache = self.catalog_cache.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(hit) = cache.get(&resolved.lang) {
+            if let Some(hit) = cache.get(lang) {
                 hit.clone()
             } else {
-                let built = crate::i18n::Catalog::build(&self.paths.config_dir, &resolved.lang);
+                let built = crate::i18n::Catalog::build(&self.paths.config_dir, lang);
                 if cache.len() < MAX_CATALOG_CACHE {
-                    cache.insert(resolved.lang.clone(), built.clone());
+                    cache.insert(lang.to_string(), built.clone());
                 }
                 built
             }
         };
-        crate::i18n::Translator::new(resolved.lang, catalog)
+        crate::i18n::Translator::new(lang.to_string(), catalog)
     }
 
     fn maybe_pick_tip(
@@ -617,6 +641,16 @@ impl Engine {
                     );
                 }
             }
+        }
+
+        // A redirect target (`cat > fi`, `sort < in`) sits alone in its
+        // pipeline segment, so `parsed.command` is None whenever the target is
+        // empty or dash-prefixed (`cat > `, `cat > -n`); the command-gated
+        // dispatch below then never runs, leaving those a dead prompt (review
+        // P2). F3 already classifies a redirect target's active token as a
+        // Path, so offer filesystem completion (files + dirs) for it directly.
+        if parsed.command.is_none() && matches!(parsed.role, TokenRole::Path) {
+            self.collect_path_candidates(active, &req.cwd, false, &mut candidates, &mut seen)?;
         }
 
         if let Some(command) = parsed.command.as_deref() {
@@ -1652,9 +1686,11 @@ impl Engine {
                 meta: CompletionMeta {
                     description: candidate.description.clone(),
                 },
-                // Filled in by `complete` once the whole-line/cursor context
-                // is known (see `whole_line_replacement_context`).
+                // Both filled in by `complete` once the command-position and
+                // whole-line/cursor context are known (see the marking loop and
+                // `whole_line_replacement_context`).
                 full_line: false,
+                verbatim: false,
             },
             item_key: history_key,
             features,
@@ -3285,7 +3321,14 @@ mod tests {
     #[test]
     fn record_command_skips_when_disabled() {
         let (mut engine, _dir) = test_engine("rec-disabled");
+        // `record_command` reloads `enabled` from disk per call so a live
+        // `config set enabled false` takes effect without a daemon restart —
+        // so the disabled state must be persisted, not just set in memory.
         engine.config.enabled = false;
+        engine
+            .config
+            .save(&engine.paths)
+            .expect("persist disabled config");
         engine
             .record_command(record_req("ls -la", "/tmp"))
             .expect("record");
@@ -3293,6 +3336,34 @@ mod tests {
             engine.db.latest_command().expect("latest"),
             None,
             "nothing is recorded while shac is disabled"
+        );
+    }
+
+    #[test]
+    fn record_command_honors_disable_written_after_engine_start() {
+        // The daemon caches config at startup; disabling AFTER that must still
+        // stop recording (the review's stale-gate P1). Start enabled, record
+        // one command, then disable on disk and confirm the next is dropped.
+        let (engine, _dir) = test_engine("rec-disable-live");
+        engine
+            .record_command(record_req("ls -la", "/tmp"))
+            .expect("record while enabled");
+        assert_eq!(
+            engine.db.latest_command().expect("latest").as_deref(),
+            Some("ls -la"),
+        );
+
+        let mut disabled = engine.config.clone();
+        disabled.enabled = false;
+        disabled.save(&engine.paths).expect("persist disable");
+
+        engine
+            .record_command(record_req("git status", "/tmp"))
+            .expect("record while disabled");
+        assert_eq!(
+            engine.db.latest_command().expect("latest").as_deref(),
+            Some("ls -la"),
+            "a command recorded after a live disable must be dropped"
         );
     }
 
@@ -3317,6 +3388,10 @@ mod tests {
             line_item.full_line,
             "multi-word history at command position must be a full line"
         );
+        assert!(
+            line_item.verbatim,
+            "a whole-buffer history line is also verbatim (not escaped)"
+        );
 
         // Mid-line argument completion offers a single token — nothing here is
         // a whole-buffer replacement, so no item may be flagged full_line.
@@ -3329,6 +3404,70 @@ mod tests {
                 "mid-line candidate must not be full_line: {item:?}"
             );
         }
+    }
+
+    #[test]
+    fn whole_line_history_after_operator_is_verbatim_but_not_full_line() {
+        // A resurrected history line offered at a chained command position
+        // (after `&&`) is still a whole shell line → must insert VERBATIM (not
+        // per-token escaped, which would break it: `git\ commit\ -m\ wip`), but
+        // it does NOT replace the whole buffer → Enter must NOT run it. This is
+        // the chained-command escaping regression the split of verbatim from
+        // full_line fixes.
+        let (engine, _dir) = test_engine("verbatim-chained");
+        engine
+            .record_command(record_req("git commit -m wip", "/tmp"))
+            .expect("record");
+
+        let resp = engine
+            .complete(make_request("cd /tmp && gi", "/tmp"))
+            .expect("complete");
+        let item = resp
+            .items
+            .iter()
+            .find(|i| i.insert_text == "git commit -m wip")
+            .expect("whole-line history candidate should be offered after &&");
+        assert!(
+            item.verbatim,
+            "a whole shell line at any command position must be verbatim"
+        );
+        assert!(
+            !item.full_line,
+            "a non-whole-buffer line must not be Enter-runnable"
+        );
+    }
+
+    #[test]
+    fn redirect_target_offers_file_completion() {
+        let (engine, dir) = test_engine("redirect-target");
+        let cwd = dir.path.to_string_lossy().to_string();
+        std::fs::write(dir.path.join("output.log"), "").expect("seed file");
+
+        // `cat > <Tab>` — empty redirect target, no command in the segment:
+        // must still offer filesystem candidates, not dead air (review P2).
+        let empty = engine
+            .complete(make_request("cat > ", &cwd))
+            .expect("complete");
+        assert!(
+            empty
+                .items
+                .iter()
+                .any(|i| i.insert_text.contains("output.log")),
+            "empty redirect target should offer files: {:?}",
+            empty.items
+        );
+
+        // A typed prefix filters to the matching file.
+        let pref = engine
+            .complete(make_request("cat > o", &cwd))
+            .expect("complete");
+        assert!(
+            pref.items
+                .iter()
+                .any(|i| i.insert_text.contains("output.log")),
+            "prefixed redirect target should offer matching files: {:?}",
+            pref.items
+        );
     }
 
     fn make_request(line: &str, cwd: &str) -> CompletionRequest {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -216,6 +216,24 @@ impl Engine {
 
         items.sort_by(|left, right| cmp_score(right.item.score, left.item.score));
         items.truncate(self.config.max_results);
+
+        // Mark whole-line candidates (F3/F7/F8). A history/transition entry is
+        // a full command line only when the user is completing the whole buffer
+        // from the start — the active token spans the entire (trimmed) line and
+        // the cursor is at the end — so replacing the token replaces the buffer.
+        // In any other position `project_history_candidate` already returns a
+        // single token, which must stay a per-token insert. Erring toward
+        // `false` is safe: a missed full-line just makes Enter insert instead of
+        // run; a false full-line would run a half-built command.
+        if whole_line_replacement_context(&req, &parsed) {
+            for item in &mut items {
+                item.item.full_line = matches!(
+                    item.item.source.as_str(),
+                    "history" | "runtime_history" | "transition"
+                ) && item.item.insert_text.contains(' ');
+            }
+        }
+
         let response_sources: Vec<String> = items.iter().map(|i| i.item.source.clone()).collect();
         let tip = self.maybe_pick_tip(&req, &response_sources, items.len());
         let request_id = self.db.record_completion_request(
@@ -1634,6 +1652,9 @@ impl Engine {
                 meta: CompletionMeta {
                     description: candidate.description.clone(),
                 },
+                // Filled in by `complete` once the whole-line/cursor context
+                // is known (see `whole_line_replacement_context`).
+                full_line: false,
             },
             item_key: history_key,
             features,
@@ -2654,6 +2675,15 @@ fn python_module_candidates() -> &'static [PythonModuleCandidate] {
     ]
 }
 
+/// Whether the completion context is a whole-buffer replacement: the cursor is
+/// at the end of the line and the active token spans the entire (trimmed)
+/// buffer. Only in this context is a multi-word history/transition candidate a
+/// real full command line (see `project_history_candidate`, which returns the
+/// whole entry only in `TokenRole::Command`). `cursor` is a character offset.
+fn whole_line_replacement_context(req: &CompletionRequest, parsed: &ParsedContext) -> bool {
+    req.cursor >= req.line.chars().count() && req.line.trim() == parsed.active_token
+}
+
 fn contextual_history_prefix(parsed: &ParsedContext) -> String {
     if matches!(parsed.role, TokenRole::Command) {
         return parsed.active_token.clone();
@@ -3258,6 +3288,41 @@ mod tests {
             None,
             "nothing is recorded while shac is disabled"
         );
+    }
+
+    #[test]
+    fn full_line_flag_marks_only_whole_line_history() {
+        let (engine, _dir) = test_engine("full-line-flag");
+        engine
+            .record_command(record_req("git commit -m wip", "/tmp"))
+            .expect("record");
+
+        // Completing the whole buffer from the first token ("gi", cursor at
+        // end): the resurrected history line replaces the buffer -> full_line.
+        let whole = engine
+            .complete(make_request("gi", "/tmp"))
+            .expect("complete");
+        let line_item = whole
+            .items
+            .iter()
+            .find(|i| i.insert_text == "git commit -m wip")
+            .expect("whole-line history candidate should be offered");
+        assert!(
+            line_item.full_line,
+            "multi-word history at command position must be a full line"
+        );
+
+        // Mid-line argument completion offers a single token — nothing here is
+        // a whole-buffer replacement, so no item may be flagged full_line.
+        let mid = engine
+            .complete(make_request("git com", "/tmp"))
+            .expect("complete");
+        for item in &mid.items {
+            assert!(
+                !item.full_line,
+                "mid-line candidate must not be full_line: {item:?}"
+            );
+        }
     }
 
     fn make_request(line: &str, cwd: &str) -> CompletionRequest {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2722,7 +2722,13 @@ fn project_history_candidate(
     // SubcommandOrArg position, but a real subcommand never starts with `-`.
     // Classify it as an option so it inserts bare instead of getting the
     // leading-dash `./` path guard (which would yield the broken `bash ./--help`).
-    let kind = if token.starts_with('-') {
+    //
+    // But NOT in a path context: there a `-notes` history token denotes a file
+    // literally named `-notes`, and must keep kind `path` so `quote_token`
+    // applies the `./` guard (`./-notes`). Marking it `option` would let a
+    // history entry shadow the real path candidate and pass `-notes` to the
+    // command as flags (codex/#35).
+    let kind = if token.starts_with('-') && !matches!(parsed.role, TokenRole::Path) {
         "option"
     } else {
         match parsed.role {
@@ -3502,6 +3508,34 @@ mod tests {
             project_history_candidate("bash script.sh", &parsed).expect("arg candidate");
         assert_eq!(token, "script.sh");
         assert_eq!(kind, "subcommand");
+    }
+
+    #[test]
+    fn project_history_candidate_keeps_dash_token_as_path_in_path_context() {
+        // In a Path context (e.g. `vim -notes` where the arg slot is path-like),
+        // a dash-prefixed history token is a filename, not a flag: it must stay
+        // kind "path" so the `./` guard applies on accept (`./-notes`) rather
+        // than being marked "option" and shadowing the real path candidate
+        // (codex/#35).
+        let parsed = ParsedContext {
+            line_before_cursor: "vim ".to_string(),
+            tokens: vec!["vim".to_string(), String::new()],
+            active_token: String::new(),
+            active_index: 1,
+            role: TokenRole::Path,
+            command: Some("vim".to_string()),
+            prev_token: Some("vim".to_string()),
+            project_markers: Vec::new(),
+            open_quote: None,
+        };
+
+        let (token, _display, kind) =
+            project_history_candidate("vim -notes", &parsed).expect("path candidate");
+        assert_eq!(token, "-notes");
+        assert_eq!(
+            kind, "path",
+            "a dash token in a path context stays a path, not an option"
+        );
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -41,7 +41,7 @@ impl Catalog {
     /// A safe locale token: 2–16 chars of ASCII alphanumerics plus `-`/`_`
     /// (e.g. `en`, `en-US`, `zh_CN`). Rejects anything path-shaped (`/`, `.`,
     /// `..`, absolute) — see `build`.
-    fn is_safe_lang_check(lang: &str) -> bool {
+    pub fn is_safe_lang_check(lang: &str) -> bool {
         (2..=16).contains(&lang.len())
             && lang
                 .chars()

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -38,8 +38,27 @@ impl Catalog {
 
     /// Build catalog: bundled `en` + bundled `<lang>` (none yet) + user override at
     /// `<config_dir>/locales/<lang>.toml` and/or `<config_dir>/locales/en.toml`.
+    /// A safe locale token: 2–16 chars of ASCII alphanumerics plus `-`/`_`
+    /// (e.g. `en`, `en-US`, `zh_CN`). Rejects anything path-shaped (`/`, `.`,
+    /// `..`, absolute) — see `build`.
+    fn is_safe_lang_check(lang: &str) -> bool {
+        (2..=16).contains(&lang.len())
+            && lang
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    }
+
     pub fn build(config_dir: &Path, lang: &str) -> Self {
         let mut catalog = Self::bundled_en();
+        // `lang` can come from the untrusted `SHAC_LOCALE` request env. A `/`,
+        // `..`, or absolute path would make `Path::join` read an arbitrary
+        // `.toml` (F5); an unbounded string would also bloat the catalog cache.
+        // Restrict to a plain locale token (e.g. `en`, `pt-BR`); else fall back.
+        let lang = if Self::is_safe_lang_check(lang) {
+            lang
+        } else {
+            "en"
+        };
         let user_lang = config_dir.join("locales").join(format!("{lang}.toml"));
         if lang != "en" && user_lang.exists() {
             match fs::read_to_string(&user_lang) {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -5,8 +5,7 @@ use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::Result;
 
@@ -197,14 +196,24 @@ fn upsert_static_docs(db: &AppDb, command: &str) -> Result<()> {
     Ok(())
 }
 
-/// Upsert docs by running `<cmd> --help`. Caller MUST verify that `command`
-/// is not a GUI app via `is_gui_app` first — this function will happily
-/// shell out to anything. Falls back to static_docs if help parse yields
-/// nothing (covers tools that print help to a man page or stderr).
+/// Upsert docs for `command`, preferring the cleanest source for flag/subcommand
+/// completion. Caller MUST verify that `command` is not a GUI app via
+/// `is_gui_app` first — this function will happily shell out to anything.
+///
+/// Priority: bundled `static_docs` (curated, highest quality) → `<cmd> --help`
+/// (concise, structured flag list — ideal for completion) → `man` (fallback for
+/// tools whose `--help` is empty or prints only to a man page). `--help` is
+/// primary because its terse per-flag rows parse far more cleanly than man's
+/// prose; man is the safety net, not the default.
+///
+/// NB: before F10 fixed the shellout pipe-buffer deadlock, `man` silently
+/// timed out on any page over ~64 KiB, so `--help` was the de-facto primary
+/// source regardless of ordering. Making the order explicit here keeps that
+/// observed behavior stable now that `man` actually works.
 fn upsert_docs_with_help_shellout(db: &AppDb, command: &str) -> Result<()> {
     let docs = static_docs(command)
-        .or_else(|| parse_man_output(command))
         .or_else(|| parse_help_output(command))
+        .or_else(|| parse_man_output(command))
         .unwrap_or_default();
     if !docs.is_empty() {
         db.replace_docs_for_command(command, &docs)?;
@@ -253,7 +262,7 @@ fn is_subcommand_name(token: &str) -> bool {
 
 fn parse_help_output(command: &str) -> Option<Vec<StoredDoc>> {
     let output = run_help_with_timeout(command, HELP_TIMEOUT)?;
-    if !output.status.success() && output.stdout.is_empty() {
+    if !output.success && output.stdout.is_empty() {
         return None;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -302,58 +311,27 @@ fn parse_help_text(command: &str, stdout: &str) -> Vec<StoredDoc> {
     docs
 }
 
-fn run_help_with_timeout(command: &str, timeout: Duration) -> Option<std::process::Output> {
-    let mut child = Command::new(command)
-        .arg("--help")
+fn run_help_with_timeout(command: &str, timeout: Duration) -> Option<crate::proc::CapturedOutput> {
+    let mut cmd = Command::new(command);
+    cmd.arg("--help")
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .env("TERM", "dumb")
         .env("NO_COLOR", "1")
         .env_remove("DISPLAY")
-        .env_remove("WAYLAND_DISPLAY")
-        .spawn()
-        .ok()?;
-    let start = Instant::now();
-    loop {
-        if child.try_wait().ok()?.is_some() || start.elapsed() >= timeout {
-            break;
-        }
-        thread::sleep(Duration::from_millis(10));
-    }
-    if start.elapsed() >= timeout {
-        let _ = child.kill();
-    }
-    child.wait_with_output().ok()
+        .env_remove("WAYLAND_DISPLAY");
+    crate::proc::run_capture(cmd, timeout)
 }
 
 fn parse_man_output(command: &str) -> Option<Vec<StoredDoc>> {
-    let mut child = Command::new("man")
-        .args(["-P", "cat", command])
+    let mut cmd = Command::new("man");
+    cmd.args(["-P", "cat", command])
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .env("MANWIDTH", "200")
-        .env("MANPAGER", "cat")
-        .spawn()
-        .ok()?;
-    let start = Instant::now();
-    let timed_out = loop {
-        if child.try_wait().ok()?.is_some() {
-            break false;
-        }
-        if start.elapsed() >= MAN_TIMEOUT {
-            break true;
-        }
-        thread::sleep(Duration::from_millis(10));
-    };
-    if timed_out {
-        let _ = child.kill();
-        let _ = child.wait();
-        return None;
-    }
-    let output = child.wait_with_output().ok()?;
-    if !output.status.success() || output.stdout.is_empty() {
+        .env("MANPAGER", "cat");
+    let output = crate::proc::run_capture(cmd, MAN_TIMEOUT)?;
+    if !output.success || output.stdout.is_empty() {
         return None;
     }
     let raw = String::from_utf8_lossy(&output.stdout);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod i18n;
 pub mod import;
 pub mod indexer;
 pub mod priors;
+pub mod proc;
 pub mod profiles;
 pub mod protocol;
 pub mod quote;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -13,12 +13,39 @@
 //! truncation/timeout bug, not a theoretical one. Centralizing the pattern
 //! here — with a reader thread that drains stdout in parallel — fixes all six
 //! sites at once (F10).
+//!
+//! Draining alone is not enough, because `child.kill()` only signals the
+//! *direct* child: a grandchild that inherited the stdout pipe (a backgrounded
+//! job, `man`'s groff/cat pipeline, a shim script that forks) keeps the write
+//! end open, so `read_to_end` never sees EOF. To bound that, the child runs in
+//! its own process group (`process_group(0)`) so a timeout can SIGKILL the
+//! whole tree, and the final collect uses `recv_timeout` — a descendant that
+//! escapes the group (double-fork) can then leak the reader thread but can
+//! never wedge the (single-threaded) daemon's accept loop past the grace
+//! window.
 
 use std::io::Read;
+use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
+
+/// How long the final stdout collect waits before giving up on a descendant
+/// that's still holding the pipe. On timeout the reader thread is detached
+/// (one leaked thread + its partial buffer is strictly better than stalling
+/// every other client); after a group SIGKILL the pipe closes well within it.
+const REAP_GRACE: Duration = Duration::from_millis(200);
+
+/// SIGKILL the whole process group led by `pid` (negative pid targets the
+/// group). Best-effort: the child may already be dead/reaped, or a descendant
+/// may have left the group. Safe: `pid` is a live-or-zombie child we spawned
+/// into its own group, so the group id can't have been reused.
+fn kill_group(pid: u32) {
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGKILL);
+    }
+}
 
 /// Captured result of a timed shellout: the full stdout bytes and whether the
 /// child exited zero. Returned only when the child exited on its own before
@@ -34,18 +61,23 @@ pub struct CapturedOutput {
 /// this helper always overrides stdout to a pipe so it owns the capture.
 ///
 /// Returns `Some(CapturedOutput)` when the child exits before `timeout`,
-/// `None` on spawn failure, poll error, or timeout (the child is killed and
-/// reaped in those cases). Draining on a separate thread is what makes this
-/// safe for children whose output exceeds the pipe buffer — see the module
-/// docs.
+/// `None` on spawn failure, poll error, or timeout (the child's whole process
+/// group is killed and reaped in those cases). Draining on a separate thread
+/// plus the process-group handling is what makes this safe for children whose
+/// output exceeds the pipe buffer or that leave descendants holding it — see
+/// the module docs.
 pub fn run_capture(mut command: Command, timeout: Duration) -> Option<CapturedOutput> {
     command.stdout(Stdio::piped());
+    // New process group led by the child, so a timeout can signal the whole
+    // subtree, not just the direct child (see module docs).
+    command.process_group(0);
     let mut child = command.spawn().ok()?;
+    let pid = child.id();
     let stdout = child.stdout.take()?;
 
-    // read_to_end blocks until EOF, which arrives either when the child exits
-    // normally or when we kill it below — so the reader thread always finishes
-    // promptly and never leaks.
+    // read_to_end blocks until EOF. EOF arrives when every holder of the write
+    // end closes it — normally the child, but a descendant can extend that, so
+    // the collect below is bounded rather than a bare `recv`.
     let (tx, rx) = mpsc::channel();
     let reader = thread::spawn(move || {
         let mut stdout = stdout;
@@ -60,27 +92,43 @@ pub fn run_capture(mut command: Command, timeout: Duration) -> Option<CapturedOu
             Ok(Some(status)) => break Some(status),
             Ok(None) => {
                 if start.elapsed() >= timeout {
-                    let _ = child.kill();
+                    kill_group(pid);
                     let _ = child.wait();
                     break None;
                 }
                 thread::sleep(Duration::from_millis(5));
             }
             Err(_) => {
-                let _ = child.kill();
+                kill_group(pid);
                 let _ = child.wait();
                 break None;
             }
         }
     };
 
-    // Killing/exiting the child closes the pipe's write end, so read_to_end
-    // returns and the reader thread sends its buffer. Collect it (partial
-    // output on timeout is discarded via the `status?` below) and join.
-    let stdout = rx.recv().unwrap_or_default();
+    let Some(status) = status else {
+        // Timeout/error: the group was SIGKILLed, so the pipe should close and
+        // the reader finish within REAP_GRACE. If a descendant escaped the
+        // group and still holds it, DON'T block the daemon — detach the reader
+        // (leak one thread + its partial buffer until the pipe finally closes)
+        // and give up. Output is discarded on this path regardless.
+        let _ = rx.recv_timeout(REAP_GRACE);
+        return None;
+    };
+
+    // Clean exit. The child is done, but a backgrounded descendant it spawned
+    // may still hold the pipe. Wait briefly for a normal drain; if one lingers
+    // past the grace window, force the pipe closed by killing the group and
+    // take whatever was captured — never block unboundedly.
+    let stdout = match rx.recv_timeout(REAP_GRACE) {
+        Ok(buf) => buf,
+        Err(_) => {
+            kill_group(pid);
+            rx.recv().unwrap_or_default()
+        }
+    };
     let _ = reader.join();
 
-    let status = status?;
     Some(CapturedOutput {
         stdout,
         success: status.success(),
@@ -133,5 +181,42 @@ mod tests {
     fn nonzero_exit_is_reported() {
         let out = run_capture(sh("exit 3"), Duration::from_secs(5)).expect("child should exit");
         assert!(!out.success);
+    }
+
+    #[test]
+    fn timeout_with_backgrounded_child_does_not_hang() {
+        // The direct child blocks on a foreground `sleep 30` while a
+        // backgrounded `sleep 30` inherits and holds the stdout pipe. The old
+        // bare `recv()` blocked until that grandchild exited (~30s). The
+        // group-kill + bounded recv must return well inside the bound.
+        // (Bound deliberately loose — expected ~0.3s, bug ~30s.)
+        let start = Instant::now();
+        let out = run_capture(
+            sh("sleep 30 & printf hi; sleep 30"),
+            Duration::from_millis(100),
+        );
+        let elapsed = start.elapsed();
+        assert!(out.is_none(), "a timed-out capture yields None");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must not block on the inherited pipe (took {elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn clean_exit_with_backgrounded_child_returns_promptly() {
+        // The direct child exits cleanly but leaves a backgrounded `sleep 30`
+        // holding the pipe. We must return the child's own output without
+        // waiting out the grandchild's lifetime.
+        let start = Instant::now();
+        let out = run_capture(sh("sleep 30 & printf hi"), Duration::from_secs(10))
+            .expect("child exits cleanly");
+        let elapsed = start.elapsed();
+        assert!(out.success);
+        assert_eq!(out.stdout, b"hi");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "clean exit must not wait for the backgrounded child (took {elapsed:?})"
+        );
     }
 }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,0 +1,137 @@
+//! Run a child process with a hard wall-clock timeout, draining stdout
+//! concurrently so a child that fills the OS pipe buffer can't deadlock.
+//!
+//! Every daemon-side shellout (`git for-each-ref`, `kubectl api-resources`,
+//! `docker images/ps`, `<cmd> --help`, `man`) previously followed the same
+//! shape: spawn with stdout piped, poll `try_wait()` in a sleep loop, kill on
+//! timeout, then read stdout *after* the child exited. That ordering
+//! deadlocks whenever the child writes more than one pipe buffer (~64 KiB on
+//! macOS/Linux) before exiting: the child blocks in `write()` waiting for a
+//! reader, we block waiting for it to exit, and the timeout fires and kills a
+//! process that was only ever stuck because we refused to read it. `man` and
+//! large `--help` outputs routinely exceed 64 KiB, so this was a real
+//! truncation/timeout bug, not a theoretical one. Centralizing the pattern
+//! here — with a reader thread that drains stdout in parallel — fixes all six
+//! sites at once (F10).
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Captured result of a timed shellout: the full stdout bytes and whether the
+/// child exited zero. Returned only when the child exited on its own before
+/// the deadline; a timeout, spawn failure, or missing stdout handle yields
+/// `None`.
+pub struct CapturedOutput {
+    pub stdout: Vec<u8>,
+    pub success: bool,
+}
+
+/// Spawn `command` with stdout piped, drain stdout on a dedicated thread, and
+/// enforce a hard `timeout`. The caller configures args/env/stdin/stderr;
+/// this helper always overrides stdout to a pipe so it owns the capture.
+///
+/// Returns `Some(CapturedOutput)` when the child exits before `timeout`,
+/// `None` on spawn failure, poll error, or timeout (the child is killed and
+/// reaped in those cases). Draining on a separate thread is what makes this
+/// safe for children whose output exceeds the pipe buffer — see the module
+/// docs.
+pub fn run_capture(mut command: Command, timeout: Duration) -> Option<CapturedOutput> {
+    command.stdout(Stdio::piped());
+    let mut child = command.spawn().ok()?;
+    let stdout = child.stdout.take()?;
+
+    // read_to_end blocks until EOF, which arrives either when the child exits
+    // normally or when we kill it below — so the reader thread always finishes
+    // promptly and never leaks.
+    let (tx, rx) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let mut stdout = stdout;
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+        }
+    };
+
+    // Killing/exiting the child closes the pipe's write end, so read_to_end
+    // returns and the reader thread sends its buffer. Collect it (partial
+    // output on timeout is discarded via the `status?` below) and join.
+    let stdout = rx.recv().unwrap_or_default();
+    let _ = reader.join();
+
+    let status = status?;
+    Some(CapturedOutput {
+        stdout,
+        success: status.success(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build `/bin/sh -c <script>` with an explicit PATH. This keeps the tests
+    /// hermetic: cargo runs a binary's unit tests as parallel threads in one
+    /// process, and other tests (e.g. `list_kubectl_resources`) mutate the
+    /// process-global `PATH` via `std::env::set_var("PATH", "/dev/null")` to
+    /// exercise their not-on-PATH branch. Resolving `sh`/`yes`/`head` through
+    /// the inherited PATH would race those and fail with NotFound. Absolute
+    /// `/bin/sh` needs no lookup, and the explicit PATH covers the utilities
+    /// the scripts pipe through.
+    fn sh(script: &str) -> Command {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", script]).env("PATH", "/usr/bin:/bin");
+        cmd
+    }
+
+    #[test]
+    fn captures_small_output() {
+        let out =
+            run_capture(sh("printf hello"), Duration::from_secs(5)).expect("child should exit");
+        assert!(out.success);
+        assert_eq!(out.stdout, b"hello");
+    }
+
+    #[test]
+    fn captures_large_output_without_deadlock() {
+        // Emit far more than one pipe buffer (~64 KiB). The old "read after
+        // exit" pattern would deadlock here; the concurrent reader must not.
+        let out = run_capture(sh("yes shac | head -c 1000000"), Duration::from_secs(10))
+            .expect("child should exit");
+        assert!(out.success);
+        assert_eq!(out.stdout.len(), 1_000_000);
+    }
+
+    #[test]
+    fn times_out_and_returns_none() {
+        let out = run_capture(sh("sleep 30"), Duration::from_millis(100));
+        assert!(out.is_none(), "a process past its deadline must yield None");
+    }
+
+    #[test]
+    fn nonzero_exit_is_reported() {
+        let out = run_capture(sh("exit 3"), Duration::from_secs(5)).expect("child should exit");
+        assert!(!out.success);
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -61,6 +61,18 @@ pub struct CompletionItem {
     pub score: f64,
     pub source: String,
     pub meta: CompletionMeta,
+    /// True when this candidate is a whole command line that replaces the
+    /// entire buffer (resurrected from history/transitions while the user is
+    /// typing the first token), rather than a single token spliced into the
+    /// active position. The daemon is the single source of truth for this: it
+    /// alone knows the source, the multi-word shape, and the line/cursor
+    /// context. Widgets key their insert-vs-replace and Enter-runs-vs-inserts
+    /// behavior off this one flag instead of re-deriving it from `kind`/`source`
+    /// heuristics that used to drift apart (F3/F7/F8). `#[serde(default)]`
+    /// keeps parsing an older daemon's response (no field) safe — it reads as
+    /// `false`, the conservative "treat as a plain token" default.
+    #[serde(default)]
+    pub full_line: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -73,6 +73,17 @@ pub struct CompletionItem {
     /// `false`, the conservative "treat as a plain token" default.
     #[serde(default)]
     pub full_line: bool,
+    /// True when `insert_text` is a whole shell line that is already valid
+    /// syntax and must be inserted VERBATIM, not per-token escaped (escaping
+    /// would turn `git commit -m wip` into `git\ commit\ -m\ wip`, one broken
+    /// word). This is the escaping counterpart of `full_line` and a strict
+    /// SUPERSET of it: a resurrected history/transition line is verbatim at
+    /// *any* command position (buffer start or after `&&`/`|`/`;`), whereas
+    /// `full_line` (Enter-runs-it) holds only when it also replaces the whole
+    /// buffer. Keeping the two separate is what fixes the chained-command
+    /// escaping regression. Drives the CLI's quoting decision.
+    #[serde(default)]
+    pub verbatim: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/bash_readline_point.rs
+++ b/tests/bash_readline_point.rs
@@ -218,7 +218,9 @@ fn last_request_id_after(header_response: &str) -> String {
         r#"
 export PATH="{dir}:$PATH"
 source "{script_path}"
-_shac_last_request_id=""
+# Preset a STALE id so the "0"/no-request path is verified to CLEAR it, not
+# merely leave it unset.
+_shac_last_request_id="STALE"
 _shac_bash_request "foobar" 6
 printf '%s' "$_shac_last_request_id"
 "#,

--- a/tests/bash_readline_point.rs
+++ b/tests/bash_readline_point.rs
@@ -97,3 +97,80 @@ fn splice_candidate_matches_byte_offset_for_ascii_only_prefix() {
         before.len() + insert.len()
     );
 }
+
+/// Drive `_shac_bash_active_region LINE POINT` and return the (before, after)
+/// splice regions it assigns. Like `run_splice`, this exercises the function
+/// directly by sourcing the script and reading the plain globals it sets.
+fn run_active_region(line: &str, point: usize) -> (String, String) {
+    let script_path = format!("{}/shell/bash/shac.bash", env!("CARGO_MANIFEST_DIR"));
+    let script = format!(
+        r#"
+source "{script_path}"
+_shac_bash_active_region {line:?} {point}
+printf '%s\n%s\n' "$_shac_bash_before" "$_shac_bash_after"
+"#,
+    );
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run bash");
+    assert!(
+        output.status.success(),
+        "bash script failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Two `printf %s\n` lines; a trailing empty region yields an empty line, so
+    // don't let `lines()` swallow it — index positionally.
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let parts: Vec<&str> = stdout.splitn(2, '\n').collect();
+    let before = parts.first().copied().unwrap_or_default().to_string();
+    let after = parts
+        .get(1)
+        .map(|rest| rest.strip_suffix('\n').unwrap_or(rest))
+        .unwrap_or_default()
+        .to_string();
+    (before, after)
+}
+
+#[test]
+fn active_region_splits_on_plain_whitespace() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // Cursor at end of the last word: `foo` is the active token, `cat ` is the
+    // untouched prefix.
+    assert_eq!(run_active_region("cat foo", 7), ("cat ".into(), "".into()));
+    // Cursor inside a middle word: the trailing ` bar` is preserved in `after`.
+    assert_eq!(
+        run_active_region("cat foo bar", 5),
+        ("cat ".into(), " bar".into())
+    );
+}
+
+#[test]
+fn active_region_is_quote_and_escape_aware() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // Whitespace inside double quotes must NOT split the token: the whole
+    // `"my fi` span is active, so a splice replaces it wholesale (F6).
+    assert_eq!(
+        run_active_region("cat \"my fi", 10),
+        ("cat ".into(), "".into())
+    );
+    // Same for single quotes...
+    assert_eq!(
+        run_active_region("echo 'a b", 9),
+        ("echo ".into(), "".into())
+    );
+    // ...and for a backslash-escaped space.
+    assert_eq!(
+        run_active_region("cat My\\ fi", 9),
+        ("cat ".into(), "".into())
+    );
+}

--- a/tests/bash_readline_point.rs
+++ b/tests/bash_readline_point.rs
@@ -1,6 +1,8 @@
 mod support;
 
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// MINOR fix: on the bash>=4 `bind -x` accept path, `_shac_bash_splice_candidate`
 /// (shell/bash/shac.bash) must set `READLINE_POINT` to a BYTE offset -- that's
@@ -172,5 +174,171 @@ fn active_region_is_quote_and_escape_aware() {
     assert_eq!(
         run_active_region("cat My\\ fi", 9),
         ("cat ".into(), "".into())
+    );
+}
+
+/// Drive `_shac_bash_request` against a fake `shac` on PATH that emits
+/// `header_response`, and return the resulting `_shac_last_request_id`.
+fn last_request_id_after(header_response: &str) -> String {
+    let script_path = format!("{}/shell/bash/shac.bash", env!("CARGO_MANIFEST_DIR"));
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("shac-reqid-{}-{}", std::process::id(), nanos));
+    std::fs::create_dir_all(&dir).expect("mk fake bin dir");
+    let respfile = dir.join("resp.txt");
+    std::fs::write(&respfile, header_response).expect("write canned response");
+    let fake = dir.join("shac");
+    std::fs::write(
+        &fake,
+        format!("#!/bin/sh\ncat {:?}\n", respfile.to_string_lossy()),
+    )
+    .expect("write fake shac");
+    std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).expect("chmod fake");
+
+    let script = format!(
+        r#"
+export PATH="{dir}:$PATH"
+source "{script_path}"
+_shac_last_request_id=""
+_shac_bash_request "foobar" 6
+printf '%s' "$_shac_last_request_id"
+"#,
+        dir = dir.display(),
+        script_path = script_path,
+    );
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run bash");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        output.status.success(),
+        "bash script failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// Create a temp dir with the given entries (name, is_dir), then run
+/// `_shac_bash_default_fallback token` with `before`/`after` splice regions,
+/// returning the resulting (READLINE_LINE, READLINE_POINT). READLINE_LINE is
+/// preset to "PRESET" so a no-op (guarded token) is observable as unchanged.
+fn run_default_fallback(
+    entries: &[(&str, bool)],
+    before: &str,
+    after: &str,
+    token: &str,
+) -> (String, String) {
+    let script_path = format!("{}/shell/bash/shac.bash", env!("CARGO_MANIFEST_DIR"));
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("shac-fallback-{}-{}", std::process::id(), nanos));
+    std::fs::create_dir_all(&dir).expect("mk fallback dir");
+    for (name, is_dir) in entries {
+        if *is_dir {
+            std::fs::create_dir_all(dir.join(name)).expect("mk entry dir");
+        } else {
+            std::fs::write(dir.join(name), "").expect("touch entry");
+        }
+    }
+    let script = format!(
+        r#"
+cd "{dir}" || exit 1
+source "{script_path}"
+_shac_bash_before={before:?}
+_shac_bash_after={after:?}
+READLINE_LINE="PRESET"
+READLINE_POINT="99"
+_shac_bash_default_fallback {token:?}
+printf '%s\n%s' "$READLINE_LINE" "$READLINE_POINT"
+"#,
+        dir = dir.display(),
+        script_path = script_path,
+    );
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run bash");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        output.status.success(),
+        "bash script failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let mut parts = stdout.splitn(2, '\n');
+    (
+        parts.next().unwrap_or_default().to_string(),
+        parts.next().unwrap_or_default().to_string(),
+    )
+}
+
+#[test]
+fn default_fallback_completes_unique_and_common_prefix() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // Unique dir match gets completed with a trailing slash, spliced between
+    // the before/after regions.
+    let (line, point) = run_default_fallback(&[("Documents", true)], "cat ", "", "Doc");
+    assert_eq!(line, "cat Documents/");
+    assert_eq!(point, "14"); // byte length of "cat Documents/"
+
+    // Two matches: insert only the longest common prefix ("Do"), no slash.
+    let (line, _) =
+        run_default_fallback(&[("Documents", true), ("Downloads", true)], "cat ", "", "D");
+    assert_eq!(line, "cat Do");
+
+    // No match: leave the line untouched.
+    let (line, point) = run_default_fallback(&[("Documents", true)], "cat ", "", "zzz");
+    assert_eq!(line, "PRESET");
+    assert_eq!(point, "99");
+}
+
+#[test]
+fn default_fallback_skips_quoted_and_tilde_tokens() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // Tokens carrying quoting/escapes/tilde are left a no-op (can't safely
+    // reconstruct intent) — READLINE_LINE stays untouched.
+    for token in ["\"Doc", "~/Doc", "My\\ D"] {
+        let (line, _) = run_default_fallback(&[("Documents", true)], "cat ", "", token);
+        assert_eq!(line, "PRESET", "token {token:?} must be a no-op");
+    }
+}
+
+#[test]
+fn request_id_zero_sentinel_is_treated_as_no_request() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // A zero-candidate response keeps the TSV request-id field non-empty for
+    // wire alignment (F2), sending the sentinel "0". The adapter must NOT adopt
+    // it as a live request id, else a no-match Tab followed by running the line
+    // records --accepted-request-id 0 and the server mis-attributes it (codex/#40).
+    assert_eq!(
+        last_request_id_after("__shac_request_id\t0\treplace_token\t0\n"),
+        "",
+        "the \"0\" sentinel must be neutralized to no-request"
+    );
+
+    // A genuine positive request id is still adopted normally.
+    assert_eq!(
+        last_request_id_after("__shac_request_id\t42\treplace_token\t0\n"),
+        "42",
+        "a real request id must still be recorded"
     );
 }

--- a/tests/bash_readline_point.rs
+++ b/tests/bash_readline_point.rs
@@ -177,6 +177,23 @@ fn active_region_is_quote_and_escape_aware() {
     );
 }
 
+#[test]
+fn active_region_uses_character_offsets_for_multibyte() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // `mv Café tmp` — `Café` is 4 chars but 5 bytes. The cursor after `Café`
+    // is CHAR offset 7. `_shac_bash_complete` now converts READLINE_POINT
+    // (bytes) to chars before calling this, so the walker selects `Café`, not
+    // `tmp` — the F9 mid-line multibyte bug.
+    assert_eq!(
+        run_active_region("mv Café tmp", 7),
+        ("mv ".into(), " tmp".into())
+    );
+}
+
 /// Drive `_shac_bash_request` against a fake `shac` on PATH that emits
 /// `header_response`, and return the resulting `_shac_last_request_id`.
 fn last_request_id_after(header_response: &str) -> String {
@@ -301,6 +318,28 @@ fn default_fallback_completes_unique_and_common_prefix() {
     let (line, point) = run_default_fallback(&[("Documents", true)], "cat ", "", "zzz");
     assert_eq!(line, "PRESET");
     assert_eq!(point, "99");
+}
+
+#[test]
+fn default_fallback_completes_commands_not_files_at_command_position() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // At the command position (empty `before`), a token that matches only a
+    // FILE in cwd must NOT be completed to that filename — readline completes
+    // command names there. `zzqx` matches the cwd file but no command, so the
+    // fallback is a no-op (line untouched).
+    let (line, _) = run_default_fallback(&[("zzqxfile.txt", false)], "", "", "zzqx");
+    assert_eq!(
+        line, "PRESET",
+        "a file match must not complete at the command position"
+    );
+
+    // Control: the same token DOES complete as a filename in an argument slot.
+    let (line, _) = run_default_fallback(&[("zzqxfile.txt", false)], "cat ", "", "zzqx");
+    assert_eq!(line, "cat zzqxfile.txt");
 }
 
 #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -283,3 +283,96 @@ fn path_jump_absent_when_paths_index_empty() {
         "expected no path_jump rows when paths_index is empty:\n{output}"
     );
 }
+
+/// The daemon emits an authoritative full-line flag as TSV field 7 (F3/F7/F8):
+/// "1" for a multi-word history line offered while completing the whole buffer,
+/// "0" for a single-token mid-line candidate. Every widget keys off this bit
+/// rather than re-deriving it.
+#[test]
+fn full_line_flag_emitted_as_tsv_field_seven() {
+    let env = support::TestEnv::new("full-line-tsv");
+    let _daemon = env.spawn_daemon();
+
+    support::run_ok(
+        &env,
+        [
+            "record-command",
+            "--shell",
+            "zsh",
+            "--cwd",
+            "/tmp",
+            "--command",
+            "git commit -m wip",
+            "--trust",
+            "interactive",
+            "--provenance",
+            "typed_manual",
+            "--origin",
+            "zsh_precmd",
+            "--tty-present",
+        ],
+    );
+
+    // Whole-buffer completion from the first token: the history line is full.
+    let whole = support::run_ok(
+        &env,
+        [
+            "complete",
+            "--shell",
+            "zsh",
+            "--line",
+            "gi",
+            "--cursor",
+            "2",
+            "--cwd",
+            "/tmp",
+            "--format",
+            "shell-tsv-v3",
+        ],
+    );
+    let full_line_row = whole.lines().find(|line| {
+        let f: Vec<&str> = line.split('\t').collect();
+        f.first() != Some(&"__shac_request_id") && f.get(1) == Some(&"git commit -m wip")
+    });
+    let row = full_line_row
+        .unwrap_or_else(|| panic!("whole-line history candidate should be emitted:\n{whole}"));
+    let fields: Vec<&str> = row.split('\t').collect();
+    assert_eq!(
+        fields.get(6),
+        Some(&"1"),
+        "whole-line history row must carry full_line=1 in field 7:\n{row}"
+    );
+
+    // Mid-line argument completion: nothing is a whole-buffer replacement.
+    let mid = support::run_ok(
+        &env,
+        [
+            "complete",
+            "--shell",
+            "zsh",
+            "--line",
+            "git com",
+            "--cursor",
+            "7",
+            "--cwd",
+            "/tmp",
+            "--format",
+            "shell-tsv-v3",
+        ],
+    );
+    for line in mid.lines() {
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.first() == Some(&"__shac_request_id")
+            || f.first().map(|s| s.starts_with("__shac_")) == Some(true)
+        {
+            continue;
+        }
+        if f.len() >= 7 {
+            assert_eq!(
+                f.get(6),
+                Some(&"0"),
+                "mid-line candidate must carry full_line=0:\n{line}"
+            );
+        }
+    }
+}

--- a/tests/daemon_robustness.rs
+++ b/tests/daemon_robustness.rs
@@ -288,3 +288,27 @@ fn daemon_restarts_cleanly_after_a_crash_leaves_a_stale_socket() {
     let out = support::run_ok(&env, ["invalidate-caches"]);
     assert!(out.contains("caches invalidated"));
 }
+
+// ── F5: control socket is owner-only ────────────────────────────────────────
+
+/// The control socket is unauthenticated — any local peer that can connect can
+/// run `complete`, read `stats`, or poison learning via `record-command`. The
+/// daemon chmods it to 0600 right after bind so only the owner can reach it.
+#[test]
+fn control_socket_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = support::TestEnv::new("socket-perms");
+    let _daemon = env.spawn_daemon();
+    let paths = env.app_paths();
+
+    let mode = fs::metadata(&paths.socket_file)
+        .expect("socket metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "control socket must be owner-only (0600), got {mode:o}"
+    );
+}

--- a/tests/zsh_functions.rs
+++ b/tests/zsh_functions.rs
@@ -1,6 +1,8 @@
 mod support;
 
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn zsh_preview_replaces_only_active_token() {
@@ -141,6 +143,86 @@ _shac_menu_selected_index=1
 _shac_selected_is_full_line && REPLY=yes || REPLY=no
 assert_eq "$REPLY" "no" "missing flag defaults to not full_line"
 "#,
+    );
+}
+
+/// Drive the REAL `_shac_fetch_candidates` parse loop against a fake `shac` on
+/// PATH emitting `response`, and return (full_lines, descriptions) as the
+/// comma-joined `_shac_menu_*` arrays it builds. Unlike the direct-assignment
+/// test above, this exercises the TSV field split — the layer where full_line
+/// was being lost.
+fn fetch_candidate_arrays(response: &str) -> (String, String) {
+    let script_path = std::env::current_dir()
+        .expect("cwd")
+        .join("shell/zsh/shac.zsh");
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("shac-zfetch-{}-{}", std::process::id(), nanos));
+    std::fs::create_dir_all(&dir).expect("mk fake bin dir");
+    let respfile = dir.join("resp.txt");
+    std::fs::write(&respfile, response).expect("write response");
+    let fake = dir.join("shac");
+    std::fs::write(
+        &fake,
+        format!("#!/bin/sh\ncat {:?}\n", respfile.to_string_lossy()),
+    )
+    .expect("write fake shac");
+    std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    let body = format!(
+        r#"
+export PATH="{dir}:$PATH"
+source "{script}"
+BUFFER="git st"
+CURSOR=6
+_shac_fetch_candidates
+print -r -- "${{(j:,:)_shac_menu_full_lines}}"
+print -r -- "${{(j:,:)_shac_menu_descriptions}}"
+"#,
+        dir = dir.display(),
+        script = script_path.display(),
+    );
+    let output = Command::new("zsh")
+        .arg("-f")
+        .arg("-c")
+        .arg(body)
+        .env("SHAC_ZSH_TEST_MODE", "1")
+        .output()
+        .expect("run zsh");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        output.status.success(),
+        "zsh failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let mut lines = stdout.lines();
+    (
+        lines.next().unwrap_or_default().to_string(),
+        lines.next().unwrap_or_default().to_string(),
+    )
+}
+
+#[test]
+fn zsh_fetch_preserves_full_line_flag_with_empty_description() {
+    if !support::command_available("zsh") {
+        eprintln!("skipping zsh function tests: zsh is unavailable");
+        return;
+    }
+
+    // A full-line history candidate has an EMPTY description (field 6) and
+    // full_line=1 (field 7). The candidate split must preserve the interior
+    // empty field so the flag lands in _shac_menu_full_lines, not shifted into
+    // the description slot (F3/F7/F8 regression).
+    let response = "__shac_request_id\t1\treplace_token\t1\n\
+         hist:git status\tgit status\tgit status\thistory\thistory\t\t1\n";
+    let (full_lines, descriptions) = fetch_candidate_arrays(response);
+    assert_eq!(full_lines, "1", "full_line flag must survive the TSV split");
+    assert_eq!(
+        descriptions, "",
+        "empty description must stay empty, not absorb the full_line flag"
     );
 }
 

--- a/tests/zsh_functions.rs
+++ b/tests/zsh_functions.rs
@@ -114,6 +114,37 @@ assert_eq "$_shac_menu_open" "0" "right commit closes menu"
 }
 
 #[test]
+fn zsh_selected_is_full_line_reads_daemon_flag() {
+    if !support::command_available("zsh") {
+        eprintln!("skipping zsh function tests: zsh is unavailable");
+        return;
+    }
+
+    run_zsh(
+        r#"
+# The widget must trust the daemon's field-7 flag (the _shac_menu_full_lines
+# array), not re-derive full-lineness from source/item_key (F7/F8).
+_shac_menu_full_lines=("1" "0")
+
+_shac_menu_selected_index=1
+_shac_selected_is_full_line && REPLY=yes || REPLY=no
+assert_eq "$REPLY" "yes" "flag 1 marks the selected candidate full_line"
+
+_shac_menu_selected_index=2
+_shac_selected_is_full_line && REPLY=yes || REPLY=no
+assert_eq "$REPLY" "no" "flag 0 marks the selected candidate not full_line"
+
+# An older binary emits only 6 fields, so the array entry is absent: default
+# to not-full-line (Enter inserts rather than runs a possibly-mis-escaped line).
+_shac_menu_full_lines=()
+_shac_menu_selected_index=1
+_shac_selected_is_full_line && REPLY=yes || REPLY=no
+assert_eq "$REPLY" "no" "missing flag defaults to not full_line"
+"#,
+    );
+}
+
+#[test]
 fn zsh_menu_render_respects_ui_detail_settings() {
     if !support::command_available("zsh") {
         eprintln!("skipping zsh function tests: zsh is unavailable");


### PR DESCRIPTION
The rest of the holistic Fable review, batched into one release. Each wave is a
self-contained commit that builds green with tests.

## Wave 1 — Security & resource safety (F5 + F10)
- **Owner-only state (F5):** config/data/state dirs `0700`, history DB `0600`, and the **unauthenticated control socket** `0600` right after bind (any local user could previously `complete`/`stats`/poison learning). `SHAC_LOCALE` sanitized before path-join (no `.toml` traversal); per-locale catalog cache bounded.
- **Shellout deadlock (F10):** every `git`/`kubectl`/`docker`/`--help`/`man` call read stdout *after* the child exited — a deadlock whenever the child fills the ~64 KiB pipe buffer (as `man`/large `--help` do). New `proc::run_capture` drains stdout on a reader thread concurrently with the timed wait, across all six sites. Side effect: `--help` is now reliably the primary doc source (it had been masked by `man` silently deadlocking).

## Wave 2 — Privacy & history (F4)
- `history_retention_days` config (default 365); daemon prunes `history_events` on its background tick. `0` = no persistent history.
- Never-recorded: leading-space commands (`HISTCONTROL=ignorespace` convention) and everything while disabled. Inline cd-frecency gated on the clean-interactive signal (pasted/imported `cd`s no longer seed path-jump).

## Wave 3 — Widget/daemon seam (F3/F7/F8)
- Whole-line-ness is decided **once by the daemon** and shipped as a `full_line` flag, replacing the CLI's `kind` check and each widget's `source` check — two approximations that drifted (one could escape a line per-token while the other ran it). zsh keys Enter/insert off the flag; bash/fish unchanged.
- **F3:** redirect targets (`cat > fi<Tab>`) classify as Path → file completion, not command.

## Wave 4 — bash quote-aware span (F6)
- `cat "my fi<Tab>` completes the whole `"my fi` span instead of the trailing `fi`, matching zsh's quote/escape-aware token span.

## Wave 5 — Flaky reindex timeout + release
- `shac reindex` on a large PATH legitimately takes >1.5s; the client capped the wait there and reported a false "read daemon response" failure while the daemon finished. Ceiling for this explicit command is now 30s (fixes the recurring CI flake). Bumps to v0.6.12, changelog updated.

## Verification
- Build, `fmt`, `clippy --all-targets`, and full test suite green after every wave.
- New tests: dir/db/socket perms, `proc` helper (incl. 1 MiB no-deadlock), history retention + prune, record-command privacy gates, `full_line` positive/negative (unit + E2E TSV field-7), redirect→Path, bash quote-aware span, reindex timeout floor, zsh full_line flag array.
- E2E on a real debug daemon: `gi` → `full_line=1`, `cat > R` → `README.md` path candidate, socket `srw-------` (0600).

---

## Follow-up: open codex review comments (added after review)

Triaged all 13 inline comments the codex bot left on merged PRs #28–#40 against current `HEAD`. 6 were already fixed (0.6.3 universal binary, 0.6.10 man-cap + cd-path) or obsolete (bottle pipeline removed); 1 is an unfixable transient (old-widget upgrade window); the rest are low-severity edges. Three actionable ones are fixed here:

- **request_id `0` sentinel (my own 0.6.11 F2 regression):** a zero-candidate response sends `0` (non-empty for wire alignment), which adapters treated as a live request id → a no-match Tab + run-within-30s recorded `--accepted-request-id 0` and the server mis-attributed it. zsh/bash/fish now treat `0` as no-request.
- **dash-prefix history token → path in a path context:** `vim -notes` no longer shadows the real `-notes` path candidate / drops the `./` guard.
- **bash Tab dead-key (P1):** the bash≥4 `bind -x` path now emulates default filesystem completion for simple tokens instead of returning inert when shac has no candidate.

Verified E2E: a zero-candidate completion emits `request_id=0`, a real one emits a positive id; the adapters neutralize only the sentinel.

---

## Adversarial (Fable) review round

Three parallel Fable reviewers (security/concurrency · protocol/engine · shell widgets) each returned **NEEDS WORK**. Confirmed **2 P0 + 4 P1** (several by empirical repro; the two P0s re-verified by hand) — all fixed, plus the worthwhile P2s. Every fix has a test on the exact layer that was broken.

**P0** — imported-history wipe (retention pruned `ts=0` plain-zsh imports on the first tick; now keys off `max(ts, imported_at)`); zsh dropped `full_line` (empty description field elided the flag; fixed with the `@` split flag).

**P1** — `run_capture` blocked ~30s past a 100ms budget when a grandchild held the pipe (now process-group SIGKILL + bounded recv); whole-line escaping regression after `&&`/`|`/`;` (split `verbatim` from `full_line`); stale `enabled` gate let the daemon record after disable (client + daemon now re-check); bash byte/char cursor.

**P2** — redirect targets (`cat > `) offered nothing; bash Tab fallback completes commands not files at word 0; locale cache-key sanitized; socket-mode startup warning; retention-0 doc scope.

CI green (macOS + Ubuntu + semgrep).