### PR TITLE
fix: reload-safe shell adapters so upgrades update a live shell (v0.6.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.6.13 — 2026-07-12
+
+### Fixed
+- **Upgrading shac now updates an already-open shell.** Every widget wrapped
+  all of its function definitions in a one-time load guard
+  (`_SHAC_ZSH_LOADED` / `_SHAC_BASH_LOADED` / `_SHAC_FISH_LOADED`), so the
+  `source …` line that `shac install` prints — the documented way to pick up a
+  new version — was a silent **no-op** in a shell that had already loaded shac.
+  A `brew upgrade` therefore left the old widget running against the new daemon
+  (visible as a stray `0`/`1` in the menu's description column: the new
+  `full_line` protocol field parsed by an old adapter). The adapters are now
+  reload-safe: function definitions run on every `source`, while only the
+  one-time zle wiring in zsh (which saves the original widgets) stays guarded;
+  bash and fish re-run their idempotent wiring directly.
+
+  Note: this fix helps from 0.6.13 onward. Upgrading *to* 0.6.13 from an older
+  version still has the old guard loaded, so open a new shell (or
+  `unset _SHAC_ZSH_LOADED && source ~/.config/shac/shell/shac.zsh`) once to pick
+  it up.
+
 ## v0.6.12 — 2026-07-11
 
 The rest of the holistic Fable review, batched: security, resource safety, a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "shac"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shac"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 description = "Shell autocomplete engine for bash and zsh"
 license = "MIT"

--- a/shell/bash/shac.bash
+++ b/shell/bash/shac.bash
@@ -1,8 +1,11 @@
 [[ -n "${SHAC_DISABLE:-}" ]] && return 0
 
-if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
-  _SHAC_BASH_LOADED=1
-
+# No load guard: everything below is idempotent, so re-sourcing (after `shac
+# install` or a `brew upgrade`) actually updates a live shell instead of
+# no-op'ing. Function redefinitions replace; `bind -x`/`complete -F` replace;
+# the PROMPT_COMMAND registration below dedupes itself. (Unlike zsh, bash saves
+# no original widget into a var, so nothing here must run exactly once.) The
+# body keeps its historical 2-space indent from when it was guard-wrapped.
   _shac_decode() {
     # Reverse wire-format v3 field encoding: \\->\, \t->tab, \n->LF, \r->CR.
     # An unrecognized escape (or a trailing lone backslash) passes through
@@ -511,4 +514,3 @@ if [[ -z "${_SHAC_BASH_LOADED:-}" ]]; then
         make cargo go vim nvim nano code open du df diff
     fi
   fi
-fi

--- a/shell/fish/shac.fish
+++ b/shell/fish/shac.fish
@@ -1,9 +1,10 @@
 if set -q SHAC_DISABLE
   # User opted out via SHAC_DISABLE; do nothing.
 else if status is-interactive
-  if not set -q _SHAC_FISH_LOADED
-    set -g _SHAC_FISH_LOADED 1
-
+  # No load guard: fish redefines functions and re-runs `bind`/`--on-event`
+  # handlers idempotently on every source, so re-sourcing after `shac install`
+  # (or the stale source line a `brew upgrade` leaves) actually updates a live
+  # shell. Body keeps its 4-space indent from when it was guard-wrapped.
     set -g _shac_last_request_id ""
     set -g _shac_last_accepted_item_key ""
 
@@ -155,5 +156,4 @@ else if status is-interactive
     # a later version that registers per-command completions on demand.
     bind \cf __shac_accept_suggestion
     bind -M insert \cf __shac_accept_suggestion 2>/dev/null; or true
-  end
 end

--- a/shell/zsh/shac.zsh
+++ b/shell/zsh/shac.zsh
@@ -1,8 +1,13 @@
 [[ -n "${SHAC_DISABLE:-}" ]] && return 0
 
-if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
-  _SHAC_ZSH_LOADED=1
-
+# Globals and functions below are (re)defined on EVERY `source` — so `shac
+# install` + re-source (or the source line a `brew upgrade` leaves stale)
+# actually updates an already-open shell instead of silently no-op'ing on a
+# load guard. Only the one-time zle wiring near the end of this file is guarded
+# by `_SHAC_ZSH_LOADED`: it saves the ORIGINAL widgets into `_shac_orig_*`,
+# which must happen exactly once (a second save would capture our OWN widget and
+# break the chain). The body keeps its historical 2-space indent from when the
+# whole file was guard-wrapped.
   typeset -g _shac_last_request_id=""
   typeset -g _shac_last_recorded=""
   typeset -g _shac_last_buffer=""
@@ -1092,7 +1097,13 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
     fi
   }
 
-  if [[ "${SHAC_ZSH_TEST_MODE:-0}" != "1" ]]; then
+  # One-time wiring only: saving the ORIGINAL widgets (`zle -A … _shac_orig_*`)
+  # and binding ours must run exactly once per shell — a re-source must NOT
+  # re-save (it would capture our own widget). `_SHAC_ZSH_LOADED` guards this
+  # block alone now, not the function definitions above. (Hooks already use
+  # `add-zsh-hook -D` so they're re-run-safe regardless.)
+  if [[ "${SHAC_ZSH_TEST_MODE:-0}" != "1" && -z "${_SHAC_ZSH_LOADED:-}" ]]; then
+    _SHAC_ZSH_LOADED=1
     autoload -Uz compinit
     if ! typeset -p _comps >/dev/null 2>&1; then
       compinit
@@ -1145,4 +1156,3 @@ if [[ -z "${_SHAC_ZSH_LOADED:-}" ]]; then
     add-zsh-hook preexec _shac_capture_preexec
     add-zsh-hook precmd _shac_record_precmd
   fi
-fi

--- a/tests/bash_readline_point.rs
+++ b/tests/bash_readline_point.rs
@@ -360,6 +360,44 @@ fn default_fallback_skips_quoted_and_tilde_tokens() {
 }
 
 #[test]
+fn bash_adapter_is_reload_safe() {
+    if !support::command_available("bash") {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+
+    // Re-sourcing must REDEFINE functions (so `shac install` + `source` updates
+    // a live shell), not no-op on a load guard. Source, override a function as a
+    // stale version would leave it, re-source, and confirm the real function is
+    // back.
+    let script_path = format!("{}/shell/bash/shac.bash", env!("CARGO_MANIFEST_DIR"));
+    let script = format!(
+        r#"
+source "{script_path}" 2>/dev/null
+_shac_decode() {{ REPLY="STALE"; }}
+source "{script_path}" 2>/dev/null
+_shac_decode "hello"
+printf '%s' "$REPLY"
+"#,
+    );
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run bash");
+    assert!(
+        output.status.success(),
+        "bash failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "hello",
+        "re-sourcing must redefine functions, not no-op on a load guard"
+    );
+}
+
+#[test]
 fn request_id_zero_sentinel_is_treated_as_no_request() {
     if !support::command_available("bash") {
         eprintln!("skipping: bash unavailable");

--- a/tests/zsh_functions.rs
+++ b/tests/zsh_functions.rs
@@ -146,6 +146,51 @@ assert_eq "$REPLY" "no" "missing flag defaults to not full_line"
     );
 }
 
+#[test]
+fn zsh_adapter_is_reload_safe() {
+    if !support::command_available("zsh") {
+        eprintln!("skipping zsh function tests: zsh is unavailable");
+        return;
+    }
+
+    let script_path = std::env::current_dir()
+        .expect("cwd")
+        .join("shell/zsh/shac.zsh");
+    // Source once, override a function as a stale/old version would leave it,
+    // then re-source. A reload-safe adapter must REDEFINE the function (so
+    // `shac install` + `source` actually updates a live shell); the old
+    // load-guard structure made the re-source a no-op and the override would
+    // survive.
+    let body = format!(
+        r#"
+source "{script}"
+_shac_decode() {{ REPLY="STALE" }}
+source "{script}"
+_shac_decode "hello"
+print -r -- "$REPLY"
+"#,
+        script = script_path.display(),
+    );
+    let output = Command::new("zsh")
+        .arg("-f")
+        .arg("-c")
+        .arg(body)
+        .env("SHAC_ZSH_TEST_MODE", "1")
+        .output()
+        .expect("run zsh");
+    assert!(
+        output.status.success(),
+        "zsh failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "hello",
+        "re-sourcing must redefine functions (the real _shac_decode), not \
+         no-op on the load guard and leave the STALE override"
+    );
+}
+
 /// Drive the REAL `_shac_fetch_candidates` parse loop against a fake `shac` on
 /// PATH emitting `response`, and return (full_lines, descriptions) as the
 /// comma-joined `_shac_menu_*` arrays it builds. Unlike the direct-assignment


### PR DESCRIPTION
## Problem

Every widget wrapped all its function definitions in a one-time load guard (`_SHAC_ZSH_LOADED` / `_SHAC_BASH_LOADED` / `_SHAC_FISH_LOADED`). So the `source ~/.config/shac/shell/shac.zsh` line that `shac install` prints — the documented way to pick up a new version — was a silent **no-op** in an already-loaded shell.

Result: a `brew upgrade` left the OLD widget running against the NEW daemon. Concretely visible in 0.6.12 as a stray `0`/`1` in the menu's description column — the new `full_line` TSV field (7th) parsed by an old adapter whose split collapsed the empty description field. `shac doctor` even said `zsh_adapter_current ok` (it checks the file, not what's loaded in memory), reinforcing the false sense that the upgrade took.

## Fix

Reload-safe adapters — definitions run on every `source`; only genuinely-once wiring stays guarded:

- **zsh**: function/global definitions moved out of the guard. The guard now wraps **only** the zle wiring, which does `zle -A <w> _shac_orig_<w>` (saves the *original* widget) — that must run exactly once, or a second save captures our own widget and breaks the chain. Hooks already used `add-zsh-hook -D` (idempotent).
- **bash**: guard dropped entirely — function redefinition, `bind -x`/`complete -F`, and the self-deduping `PROMPT_COMMAND` registration are all idempotent; bash saves no original into a var.
- **fish**: guard dropped — function redefinition re-registers `--on-event` handlers idempotently and `bind` replaces.

## Tests
- zsh + bash: override a function, re-source, confirm it's the real one again (fails under the old guard).
- Double-source with real zsh wiring: `_SHAC_ZSH_LOADED` set once, accept-line chain intact.
- Full suite green; all three widgets `-n` parse.

Note: helps 0.6.13 onward. Upgrading *to* 0.6.13 still needs one new shell (the old guard is already loaded) — documented in the changelog.